### PR TITLE
Keep existing dartRulesSource during resolve

### DIFF
--- a/lib/src/bazelify/arguments.dart
+++ b/lib/src/bazelify/arguments.dart
@@ -141,6 +141,7 @@ class BazelifyArguments {
     }
     return new BazelifyArguments(
       bazelExecutable: bazelResolved,
+      dartRulesSource: dartRulesSource,
       pubExecutable: pubResolved,
       pubPackageDir: workspaceResolved,
     );


### PR DESCRIPTION
We allow passing --rules-commit but that argument was getting lost after
resolving the locations for the rest of the arguments.
