### PR TITLE
add `serve` command to bazelify

### DIFF
--- a/lib/src/bazelify/arguments.dart
+++ b/lib/src/bazelify/arguments.dart
@@ -9,13 +9,114 @@ import 'package:args/args.dart';
 import 'package:path/path.dart' as p;
 import 'package:which/which.dart';
 
-/// Arguments when running `bazelify`, which adds Bazel support on top of pub.
+/// Shared arguments between all bazelify commands.
 class BazelifyArguments {
-  static final ArgParser _argParser = new ArgParser()
-    ..addOption(
-      'bazel',
-      help: 'A path to the "bazel" executable. Defauls to your PATH.',
-    )
+  /// The parser for shared arguments
+  static final ArgParser _argParser = () {
+    var parser = new ArgParser()
+      ..addOption(
+        'bazel',
+        help: 'A path to the "bazel" executable. Defauls to your PATH.',
+      )
+      ..addOption(
+        'package',
+        abbr: 'p',
+        help: 'A directory where "pubspec.yaml" is present. Defaults to CWD.',
+      );
+
+    parser.addCommand(
+        BazelifyInitArguments.command, BazelifyInitArguments._argParser);
+    parser.addCommand(
+        BazelifyServeArguments.command, BazelifyServeArguments._argParser);
+
+    return parser;
+  }();
+
+  static String getUsage() => _argParser.usage;
+
+  BazelifyArguments._({this.bazelExecutable, this.pubPackageDir});
+
+  /// Returns a [Future<BazelifyArguments>] impl by parsing [args].
+  static Future<BazelifyArguments> parse(List<String> args) async {
+    final result = _argParser.parse(args);
+
+    String bazelResolved = result['bazel'];
+    if (bazelResolved == null) {
+      bazelResolved = await which('bazel');
+    } else {
+      if (!await FileSystemEntity.isFile(bazelResolved)) {
+        throw new StateError('No "bazel" found at "$bazelResolved"');
+      }
+    }
+
+    var pubPackageDir = result['package'];
+
+    String workspaceResolved = p.normalize(pubPackageDir ?? p.current);
+    if (workspaceResolved == null) {
+      workspaceResolved = p.current;
+    }
+    workspaceResolved = p.relative(workspaceResolved);
+    if (workspaceResolved == '.') workspaceResolved = '';
+
+    var pubspec = p.join(workspaceResolved, 'pubspec.yaml');
+    if (!await FileSystemEntity.isFile(pubspec)) {
+      throw new StateError('No "pubspec" found at "${p.absolute(pubspec)}"');
+    }
+
+    switch (result.command?.name ?? BazelifyInitArguments.command) {
+      case BazelifyServeArguments.command:
+        return new BazelifyServeArguments._(
+            bazelExecutable: bazelResolved,
+            pubPackageDir: workspaceResolved,
+            target: result.command['target'],
+            watch: result.command != null
+                ? result.command['watch'] as List<String>
+                : null);
+      case BazelifyInitArguments.command:
+      default:
+        var source = DartRulesSource.stable;
+        if (result.command?.wasParsed('rules-commit') == true) {
+          source = new DartRulesSource.commit(result.command['rules-commit']);
+        } else if (result.command?.wasParsed('rules-tag') == true) {
+          source = new DartRulesSource.tag(result.command['rules-tag']);
+        } else if (result.command?.wasParsed('rules-local') == true) {
+          source = new DartRulesSource.local(result.command['rules-local']);
+        }
+
+        String pubResolved =
+            result.command != null ? result.command['pub'] : null;
+        if (pubResolved == null) {
+          pubResolved = await which('pub');
+        } else {
+          if (!await FileSystemEntity.isFile(pubResolved)) {
+            throw new StateError('No "pub" found at "$pubResolved"');
+          }
+        }
+
+        return new BazelifyInitArguments._(
+            bazelExecutable: bazelResolved,
+            dartRulesSource: source,
+            pubExecutable: pubResolved,
+            pubPackageDir: workspaceResolved);
+    }
+  }
+
+  /// A path to the 'bazel' executable.
+  ///
+  /// If `null` implicitly defaults to your PATH.
+  final String bazelExecutable;
+
+  /// A directory where `pubspec.yaml` is present.
+  final String pubPackageDir;
+}
+
+/// Arguments when running `bazelify`, which adds Bazel support on top of pub.
+class BazelifyInitArguments extends BazelifyArguments {
+  /// The name of this command.
+  static const command = 'init';
+
+  /// Parser for arguments specific to the this command.
+  static final _argParser = new ArgParser()
     ..addOption(
       'rules-commit',
       help: 'A commit SHA on dart-lang/rules_dart to use.',
@@ -31,20 +132,7 @@ class BazelifyArguments {
     ..addOption(
       'pub',
       help: 'A path to the "pub" executable. Defaults to your PATH.',
-    )
-    ..addOption(
-      'package',
-      abbr: 'p',
-      help: 'A directory where "pubspec.yaml" is present. Defaults to CWD.',
     );
-
-  /// Returns the proper usage for arguments.
-  static String getUsage() => _argParser.usage;
-
-  /// A path to the 'bazel' executable.
-  ///
-  /// If `null` implicitly defaults to your PATH.
-  final String bazelExecutable;
 
   /// A configured [DartRulesSource] for a `WORKSPACE`.
   final DartRulesSource dartRulesSource;
@@ -53,9 +141,6 @@ class BazelifyArguments {
   ///
   /// If `null` implicitly defaults to your PATH.
   final String pubExecutable;
-
-  /// A directory where `pubspec.yaml` is present.
-  final String pubPackageDir;
 
   /// Create a new set of arguments for how to run `bazelify`.
   ///
@@ -74,85 +159,50 @@ class BazelifyArguments {
   /// - [pubExecutable]: Where to find `pub`. Defaults to your PATH.
   /// - [pubPackageDir]: Where a package with a `pubspec.yaml` is. Defaults to
   ///   the current working directory.
-  BazelifyArguments({
-    this.bazelExecutable,
+  BazelifyInitArguments._({
+    String bazelExecutable,
     this.dartRulesSource: DartRulesSource.stable,
     this.pubExecutable,
-    this.pubPackageDir,
-  });
+    String pubPackageDir,
+  })
+      : super._(bazelExecutable: bazelExecutable, pubPackageDir: pubPackageDir);
+}
 
-  /// Returns a new [BazelifyArguments] by parsing [args].
-  factory BazelifyArguments.parse(List<String> args) {
-    final result = _argParser.parse(args);
-    var source = DartRulesSource.stable;
-    if (result.wasParsed('rules-commit')) {
-      source = new DartRulesSource.commit(result['rules-commit']);
-    } else if (result.wasParsed('rules-tag')) {
-      source = new DartRulesSource.tag(result['rules-tag']);
-    } else if (result.wasParsed('rules-local')) {
-      source = new DartRulesSource.local(result['rules-local']);
-    }
-    return new BazelifyArguments(
-      bazelExecutable: result['bazel'],
-      dartRulesSource: source,
-      pubExecutable: result['pub'],
-      pubPackageDir: result['package'],
-    );
-  }
+class BazelifyServeArguments extends BazelifyArguments {
+  /// The name of this command.
+  static const command = 'serve';
 
-  /// Whether all properties are set.
-  ///
-  /// If `false`, use [resolve] to find them on the PATH/CWD.
-  bool get isResolved =>
-      pubPackageDir != null && bazelExecutable != null && pubExecutable != null;
+  /// Parser for arguments specific to the this command.
+  static final _argParser = new ArgParser()
+    ..addOption('watch',
+        allowMultiple: true,
+        defaultsTo: 'web,lib,pubspec.lock',
+        help: 'A list of folders/directories to watch for changes and trigger '
+            ' builds')
+    ..addOption('target',
+        defaultsTo: 'main_ddc_serve',
+        help: 'The name of the server build target to run.',
+        hide: true);
 
-  /// Returns a [Future] that completes with a new [BazelifyArguments].
-  ///
-  /// Any implicitly default executable path is resolved to the actual location
-  /// on the user's PATH, and missing executables throw a [StateError].
-  Future<BazelifyArguments> resolve() async {
-    if (isResolved) {
-      return this;
-    }
-    String bazelResolved = bazelExecutable;
-    if (bazelResolved == null) {
-      bazelResolved = await which('bazel');
-    } else {
-      if (!await FileSystemEntity.isFile(bazelResolved)) {
-        throw new StateError('No "bazel" found at "$bazelResolved"');
-      }
-    }
-    String pubResolved = pubExecutable;
-    if (pubResolved == null) {
-      pubResolved = await which('pub');
-    } else {
-      if (!await FileSystemEntity.isFile(pubResolved)) {
-        throw new StateError('No "pub" found at "$pubResolved"');
-      }
-    }
+  /// The folders and/or files to watch and trigger builds.
+  final List<String> watch;
 
-    String workspaceResolved = p.normalize(pubPackageDir ?? p.current);
-    if (workspaceResolved == null) {
-      workspaceResolved = p.current;
-    }
-    var pubspec = p.join(workspaceResolved, 'pubspec.yaml');
-    if (!await FileSystemEntity.isFile(pubspec)) {
-      throw new StateError('No "pubspec" found at "${p.absolute(pubspec)}"');
-    }
-    return new BazelifyArguments(
-      bazelExecutable: bazelResolved,
-      dartRulesSource: dartRulesSource,
-      pubExecutable: pubResolved,
-      pubPackageDir: workspaceResolved,
-    );
-  }
+  /// The server build target to run.
+  final String target;
+
+  BazelifyServeArguments._({
+    String bazelExecutable,
+    String pubPackageDir,
+    this.target,
+    this.watch,
+  })
+      : super._(bazelExecutable: bazelExecutable, pubPackageDir: pubPackageDir);
 }
 
 /// Where to retrieve the `rules_dart`.
 abstract class DartRulesSource {
   /// The default version of [DartRulesSource] if not otherwise specified.
-  static const DartRulesSource stable =
-      const DartRulesSource.tag('0.1.1');
+  static const DartRulesSource stable = const DartRulesSource.tag('0.1.1');
 
   /// Use a git [commit].
   const factory DartRulesSource.commit(String commit) = _GitCommitRulesSource;

--- a/lib/src/bazelify/arguments.dart
+++ b/lib/src/bazelify/arguments.dart
@@ -11,7 +11,6 @@ import 'package:which/which.dart';
 
 /// Shared arguments between all bazelify commands.
 class BazelifyArguments {
-  /// The parser for shared arguments
   static final ArgParser _argParser = () {
     var parser = new ArgParser()
       ..addOption(
@@ -36,7 +35,8 @@ class BazelifyArguments {
 
   BazelifyArguments._({this.bazelExecutable, this.pubPackageDir});
 
-  /// Returns a [Future<BazelifyArguments>] impl by parsing [args].
+  /// Returns a concrete subtype of [BazelifyArguments] based on the command
+  /// found in [args].
   static Future<BazelifyArguments> parse(List<String> args) async {
     final result = _argParser.parse(args);
 
@@ -55,8 +55,6 @@ class BazelifyArguments {
     if (workspaceResolved == null) {
       workspaceResolved = p.current;
     }
-    workspaceResolved = p.relative(workspaceResolved);
-    if (workspaceResolved == '.') workspaceResolved = '';
 
     var pubspec = p.join(workspaceResolved, 'pubspec.yaml');
     if (!await FileSystemEntity.isFile(pubspec)) {
@@ -110,7 +108,8 @@ class BazelifyArguments {
   final String pubPackageDir;
 }
 
-/// Arguments when running `bazelify`, which adds Bazel support on top of pub.
+/// Arguments when running `bazelify init`, which adds Bazel support on top of
+/// pub.
 class BazelifyInitArguments extends BazelifyArguments {
   /// The name of this command.
   static const command = 'init';
@@ -142,7 +141,7 @@ class BazelifyInitArguments extends BazelifyArguments {
   /// If `null` implicitly defaults to your PATH.
   final String pubExecutable;
 
-  /// Create a new set of arguments for how to run `bazelify`.
+  /// Create a new set of arguments for how to run `bazelify init`.
   ///
   /// Will be executed locally to where [pubPackageDir] is. For example,
   /// assuming the following directory structure, the directory could be
@@ -177,7 +176,7 @@ class BazelifyServeArguments extends BazelifyArguments {
     ..addOption('watch',
         allowMultiple: true,
         defaultsTo: 'web,lib,pubspec.lock',
-        help: 'A list of folders/directories to watch for changes and trigger '
+        help: 'A list of files/directories to watch for changes and trigger '
             ' builds')
     ..addOption('target',
         defaultsTo: 'main_ddc_serve',

--- a/lib/src/bazelify/generate.dart
+++ b/lib/src/bazelify/generate.dart
@@ -10,7 +10,7 @@ import 'macro.dart';
 import 'pubspec.dart';
 import 'workspace.dart';
 
-/// Runs `bazelify` as specified in [arguments].
+/// Runs `bazelify init` as specified in [arguments].
 Future<Null> generate(BazelifyInitArguments arguments) async {
   // Start timing.
   final timings = <String, Duration>{};

--- a/lib/src/bazelify/generate.dart
+++ b/lib/src/bazelify/generate.dart
@@ -11,7 +11,7 @@ import 'pubspec.dart';
 import 'workspace.dart';
 
 /// Runs `bazelify` as specified in [arguments].
-Future<Null> generate(BazelifyArguments arguments) async {
+Future<Null> generate(BazelifyInitArguments arguments) async {
   // Start timing.
   final timings = <String, Duration>{};
   final stopwatch = new Stopwatch()..start();

--- a/lib/src/bazelify/serve.dart
+++ b/lib/src/bazelify/serve.dart
@@ -1,13 +1,22 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
+
 import 'arguments.dart';
 
 Future serve(BazelifyServeArguments args) async {
+  if (p.relative(args.pubPackageDir) != '.') {
+    print('bazelify serve only supports running from your top level package '
+        'directory.');
+    exitCode = 1;
+    return;
+  }
+
   print('Building server via bazel...\n');
   var bazelBuildProcess = await Process.start(args.bazelExecutable, [
     'build',
-    '${args.pubPackageDir}:${args.target}',
+    ':${args.target}',
     '--strategy=DartDevCompiler=worker',
     '--strategy=DartSummary=worker',
   ]);

--- a/lib/src/bazelify/serve.dart
+++ b/lib/src/bazelify/serve.dart
@@ -1,0 +1,27 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'arguments.dart';
+
+Future serve(BazelifyServeArguments args) async {
+  print('Building server via bazel...\n');
+  var bazelBuildProcess = await Process.start(args.bazelExecutable, [
+    'build',
+    '${args.pubPackageDir}:${args.target}',
+    '--strategy=DartDevCompiler=worker',
+    '--strategy=DartSummary=worker',
+  ]);
+  stdout.addStream(bazelBuildProcess.stdout);
+  stderr.addStream(bazelBuildProcess.stderr);
+  var bazelExitCode = await bazelBuildProcess.exitCode;
+  if (bazelExitCode != 0) {
+    exitCode = bazelExitCode;
+    return;
+  }
+  print('\nInitial build finished, starting server...\n');
+
+  var serverProcess = await Process.start('bazel-bin/${args.target}',
+      ['--build-target=:${args.target}', '--watch=${args.watch.join(',')}']);
+  stdout.addStream(serverProcess.stdout);
+  stderr.addStream(serverProcess.stderr);
+}


### PR DESCRIPTION
You can now run `bazelify serve` and it will serve a project. No more explicit calls to bazel necessary!

The biggest gotcha currently is it assumes the server target is called `main_ddc_serve`. It does support a `--target` option though which overrides that to whatever you want.

cc @natebosch @kevmoo @nshahan 
