### PR TITLE
Nicer error message when not run for a pub package

### DIFF
--- a/lib/src/bazelify/arguments.dart
+++ b/lib/src/bazelify/arguments.dart
@@ -43,7 +43,7 @@ Future<BazelifyArguments> sharedArguments(ArgResults result) async {
   if (!await FileSystemEntity.isFile(pubspec)) {
     print('Could not find a pubspec at ${p.absolute(pubspec)}');
     print('Please run from within a pub package directory '
-        'or pass the --package option');
+        'or specify a directory with the --package option');
     exitCode = 64;
     return null;
   }

--- a/lib/src/bazelify/arguments.dart
+++ b/lib/src/bazelify/arguments.dart
@@ -41,7 +41,11 @@ Future<BazelifyArguments> sharedArguments(ArgResults result) async {
 
   var pubspec = p.join(workspaceResolved, 'pubspec.yaml');
   if (!await FileSystemEntity.isFile(pubspec)) {
-    throw new StateError('No "pubspec" found at "${p.absolute(pubspec)}"');
+    print('Could not find a pubspec at ${p.absolute(pubspec)}');
+    print('Please run from within a pub package directory '
+        'or pass the --package option');
+    exitCode = 64;
+    return null;
   }
 
   return new BazelifyArguments(


### PR DESCRIPTION
Previously printed a stack trace, now prints a more helpful message an
no trace.
