### PR TITLE
Add a StepTimer class

### DIFF
--- a/lib/src/step_timer.dart
+++ b/lib/src/step_timer.dart
@@ -1,0 +1,20 @@
+import 'dart:async';
+
+class StepTimer {
+  final timings = <String, Duration>{};
+
+  Future/*<T>*/ run/*<T>*/(String description, Future/*<T>*/ step()) async {
+    final stopwatch = new Stopwatch()..start();
+    try {
+      return await step();
+    } finally {
+      timings[description] = stopwatch.elapsed;
+    }
+  }
+
+  void printTimings() {
+    timings.forEach((name, duration) {
+      print('$name took ${duration.inMilliseconds}ms');
+    });
+  }
+}


### PR DESCRIPTION
- Add StepTimer which can time individual steps and print all the timing
  data
- Use StepTimer from the Initialize run method to reduce duplication

The StepTimer run() method is async, which means that some time could
get lost if other futures execute between the call sight and the next
event loop. This should be fine since the data we care about is how long
each step takes, and we don't care if the steps necessarily add up
exactly to the total time.
