### PR TITLE
Update bazelify config to support builder configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,13 +151,15 @@ keys:
 - **builders**: Optional, defaults to empty. The builders to apply to this
   target. These are defined by this package or other packages in the `builders`
   section of their bazelify.yaml.
-  - A list of either a Strings or Maps. If a Map is supplied then the key is the
-    name of the builder, and the value will be parsed and passed into the
-    builder constructor as a part of the `BuilderSettings` object.
+  - **NOTE**: This is not implemented and will throw an `UnimplementedError`.
+  - A `List<String|Map>`, for Map values the key is the name of the builder, and
+    the value will be parsed and passed into the builder constructor as a part
+    of the `BuilderSettings` object.
   - There is one magic config option, `$generate_for`, which overrides the
-    targets `generate_for` option just for this builder.
+    target's `generate_for` option just for this builder.
 - **generate_for**: Optional, defaults to `sources`. The files to treat as
   inputs to all `builders`. Supports glob syntax.
+  - **NOTE**: This is not implemented and will throw an `UnimplementedError`.
 
 
 Example `targets` section for a package with two targets and some builders
@@ -193,9 +195,14 @@ targets:
 
 #### Defining `Builder`s in your package (similar to transformers)
 
+**NOTE**: Using this config is not yet implemented, adding this to your
+`bazelify.yaml` will cause an `UnimplementedError` to be thrown by bazelify
+today.
+
 If users of your package need to apply some code generation to their package,
-then you can define `Builder`s (from `package:build`) and have those be either
-be automatically applied based on existing transformer settings,or simply
+then you can define `Builder`s (from [package:build]
+(https://pub.dartlang.org/packages/build)) and have those be either be
+automatically applied based on existing transformer settings, or simply
 available for users to opt into as needed.
 
 You tell bazelify about your `Builder`s using the `builders` section of your
@@ -208,9 +215,6 @@ config may contain the following keys:
   containing the `Builder` class. This should always be a `package:` uri.
 - **class**: The name of the `Builder` class to instantiate, must be exported by
   the library referenced by `import`.
-  - We could do what transformers do and use mirrors/codegen to just find these,
-    but imo that's a bit magic and provides little benefit in this case since
-    it's only creators of builders that have to worry about it not all users.
 - **constructor**: Optional. The name of the constructor to use for `class` if
   not the default one.
   - This must follow a specific format, probably taking a single

--- a/README.md
+++ b/README.md
@@ -151,11 +151,11 @@ keys:
 - **builders**: Optional, defaults to empty. The builders to apply to this
   target. These are defined by this package or other packages in the `builders`
   section of their bazelify.yaml.
-  - May be either a String or a Map. If a Map is supplied then the key is the
+  - A list of either a Strings or Maps. If a Map is supplied then the key is the
     name of the builder, and the value will be parsed and passed into the
     builder constructor as a part of the `BuilderSettings` object.
   - There is one magic config option, `$generate_for`, which overrides the
-    targets `generate_for` option for this builder.
+    targets `generate_for` option just for this builder.
 - **generate_for**: Optional, defaults to `sources`. The files to treat as
   inputs to all `builders`. Supports glob syntax.
 
@@ -177,8 +177,8 @@ targets:
       - "some_package:web"
     builders:
       - "some_package:builder":
-        my_option: some_value
-        $generate_for:
+          my_option: some_value
+          $generate_for:
     generate_for:
       - "lib/a.dart"
   transformer:
@@ -195,8 +195,8 @@ targets:
 
 If users of your package need to apply some code generation to their package,
 then you can define `Builder`s (from `package:build`) and have those be either
-be automatically applied to all users or simply available for them to opt into
-as needed.
+be automatically applied based on existing transformer settings,or simply
+available for users to opt into as needed.
 
 You tell bazelify about your `Builder`s using the `builders` section of your
 `bazelify.yaml`. This is a map of builder names to configuration. Each builder

--- a/lib/src/bazelify/bazelify_config.dart
+++ b/lib/src/bazelify/bazelify_config.dart
@@ -16,17 +16,41 @@ class BazelifyConfig {
 
   /// Supported target config options.
   static const _targetOptions = const [
+    _builders,
     _default,
     _dependencies,
-    _sources,
     _excludeSources,
+    _generateFor,
     _platforms,
+    _sources,
   ];
+  static const _builders = 'builders';
   static const _default = 'default';
   static const _dependencies = 'dependencies';
-  static const _sources = 'sources';
   static const _excludeSources = 'exclude_sources';
+  static const _generateFor = 'generate_for';
   static const _platforms = 'platforms';
+  static const _sources = 'sources';
+
+  /// Supported builder config options.
+  static const _builderOptions = const [
+    _class,
+    _constructor,
+    _import,
+    _inputExtension,
+    _outputExtensions,
+    _replacesTransformer,
+    _sharedPartOutput,
+    _target,
+  ];
+  static const _class = 'class';
+  static const _constructor = 'constructor';
+  static const _import = 'import';
+  static const _inputExtension = 'input_extension';
+  static const _outputExtensions = 'output_extensions';
+  static const _replacesTransformer = 'replaces_transformer';
+  static const _sharedPartOutput = 'shared_part_output';
+  static const _target = 'target';
 
   /// Returns a parsed [BazelifyConfig] file in [path], if one exists.
   ///
@@ -43,7 +67,10 @@ class BazelifyConfig {
     }
   }
 
-  /// All the `libraries` defined in a `bazelify.yaml` file.
+  /// All the `builders` defined in a `bazelify.yaml` file.
+  final dartBuilderBinaries = <String, DartBuilderBinary>{};
+
+  /// All the `targets` defined in a `bazelify.yaml` file.
   final dartLibraries = <String, DartLibrary>{};
 
   /// The default config if you have no `bazelify.yaml` file.
@@ -70,48 +97,41 @@ class BazelifyConfig {
   BazelifyConfig.parse(Pubspec pubspec, String configYaml) {
     final config = loadYaml(configYaml);
 
-    var targetConfigs = config['targets'] ?? [];
+    final Map<String, Map> targetConfigs = config['targets'] ?? {};
     for (var targetName in targetConfigs.keys) {
-      var targetConfig = targetConfigs[targetName] as Map<String, dynamic>;
+      var targetConfig = _readMapOrThrow(
+          targetConfigs, targetName, _targetOptions, 'target `$targetName`');
 
-      var invalidOptions = targetConfig.keys.toList()
-          ..removeWhere((k) => _targetOptions.contains(k));
-      if (invalidOptions.isNotEmpty) {
-        throw new ArgumentError('Got invalid options `$invalidOptions` for '
-            'target `$targetName`. Only $_targetOptions are supported keys.');
-      }
+      final builders = _readBuildersOrThrow(targetConfig, _builders);
 
-      var isDefault = targetConfig[_default] ?? false;
-      if (isDefault is! bool) {
-        throw new ArgumentError(
-            'Got `$isDefault` for `$_default` but expected a boolean');
-      }
+      final dependencies = _readListOfStringsOrThrow(
+          targetConfig, _dependencies,
+          defaultValue: []);
 
-      final dependencies = targetConfig[_dependencies] ?? <String>[];
-      _checkListOfStringsOrThrow(dependencies, _dependencies);
+      final excludeSources = _readListOfStringsOrThrow(
+          targetConfig, _excludeSources,
+          defaultValue: []);
 
-      final platformsConfig = targetConfig[_platforms] ?? _allPlatforms;
-      _checkListOfStringsOrThrow(platformsConfig, _platforms);
-      final platforms = platformsConfig as List<String>;
-      var invalidPlatforms = platforms.where((p) => !_allPlatforms.contains(p));
-      if (invalidPlatforms.isNotEmpty) {
-        throw new ArgumentError('Got invalid values $invalidPlatforms for '
-            '`$_platforms`. Only $_allPlatforms are supported.');
-      }
+      var isDefault =
+          _readBoolOrThrow(targetConfig, _default, defaultValue: false);
 
-      final sources = targetConfig[_sources];
-      _checkListOfStringsOrThrow(sources, _sources);
+      final platforms = _readListOfStringsOrThrow(targetConfig, _platforms,
+          defaultValue: _allPlatforms, validValues: _allPlatforms);
 
-      final excludeSources = targetConfig[_excludeSources] ?? [];
-      _checkListOfStringsOrThrow(excludeSources, _excludeSources);
+      final sources = _readListOfStringsOrThrow(targetConfig, _sources);
+
+      final generateFor = _readListOfStringsOrThrow(targetConfig, _generateFor,
+          allowNull: true);
 
       dartLibraries[targetName] = new DartLibrary(
+        builders: builders,
         dependencies: dependencies,
-        name: targetName,
         enableDdc: platforms.contains(_webPlatform),
-        isDefault: isDefault,
-        package: pubspec.pubPackageName,
         excludeSources: excludeSources,
+        generateFor: generateFor,
+        isDefault: isDefault,
+        name: targetName,
+        package: pubspec.pubPackageName,
         sources: sources,
       );
     }
@@ -120,15 +140,130 @@ class BazelifyConfig {
       throw new ArgumentError('Found no targets with `$_default: true`. '
           'Expected exactly one.');
     }
+
+    final Map<String, Map> builderConfigs = config['builders'] ?? {};
+    for (var builderName in builderConfigs.keys) {
+      final builderConfig = _readMapOrThrow(builderConfigs, builderName,
+          _builderOptions, 'builder `$builderName`',
+          defaultValue: <String, dynamic>{});
+
+      final clazz = _readStringOrThrow(builderConfig, _class);
+      final constructor = _readStringOrThrow(builderConfig, _constructor);
+      final import = _readStringOrThrow(builderConfig, _import);
+      final inputExtension = _readStringOrThrow(builderConfig, _inputExtension);
+      final outputExtensions =
+          _readListOfStringsOrThrow(builderConfig, _outputExtensions);
+      final replacesTransformer = _readStringOrThrow(
+          builderConfig, _replacesTransformer,
+          allowNull: true);
+      final sharedPartOutput =
+          _readBoolOrThrow(builderConfig, _sharedPartOutput);
+      final target = _readStringOrThrow(builderConfig, _target);
+
+      dartBuilderBinaries[builderName] = new DartBuilderBinary(
+        clazz: clazz,
+        constructor: constructor,
+        import: import,
+        inputExtension: inputExtension,
+        name: builderName,
+        outputExtensions: outputExtensions,
+        package: pubspec.pubPackageName,
+        replacesTransformer: replacesTransformer,
+        sharedPartOutput: sharedPartOutput,
+        target: target,
+      );
+    }
   }
 
   DartLibrary get defaultDartLibrary =>
       dartLibraries.values.singleWhere((l) => l.isDefault);
 
-  static void _checkListOfStringsOrThrow(value, String option) {
+  static Map<String, Map<String, dynamic>> _readBuildersOrThrow(
+      Map<String, dynamic> options, String option) {
+    var values = options[option];
+    if (values == null) return null;
+
+    if (values is! List) {
+      throw new ArgumentError(
+          'Got `$values` for `$option` but expected a List.');
+    }
+
+    final normalizedValues = <String, Map<String, dynamic>>{};
+    for (var value in values) {
+      if (value is String) {
+        normalizedValues[value] = {};
+      } else if (value is Map) {
+        if (value.length == 1) {
+          normalizedValues[value.keys.first] = value.values.first;
+        } else {
+          throw value;
+        }
+      } else {
+        throw new ArgumentError(
+            'Got `$value` for builder but expected a String or Map');
+      }
+    }
+    return normalizedValues;
+  }
+
+  static List<String> _readListOfStringsOrThrow(
+      Map<String, dynamic> options, String option,
+      {List<String> defaultValue,
+      Iterable<String> validValues,
+      bool allowNull: false}) {
+    var value = options[option] ?? defaultValue;
+    if (value == null && allowNull) return null;
+
     if (value is! List || value.any((v) => v is! String)) {
       throw new ArgumentError(
           'Got `$value` for `$option` but expected a List<String>.');
     }
+    if (validValues != null) {
+      var invalidValues = value.where((v) => !validValues.contains(v));
+      if (invalidValues.isNotEmpty) {
+        throw new ArgumentError('Got invalid values ``$invalidValues` for '
+            '`$option`. Only `$validValues` are supported.');
+      }
+    }
+    return value;
+  }
+
+  static Map<String, dynamic> _readMapOrThrow(Map<String, dynamic> options,
+      String option, Iterable<String> validKeys, String description,
+      {Map<String, dynamic> defaultValue}) {
+    var value = options[option] ?? defaultValue;
+    if (value is! Map) {
+      throw new ArgumentError('Invalid options for `$option`, got `$value` but '
+          'expected a Map.');
+    }
+    var mapValue = value as Map<String, dynamic>;
+    var invalidOptions = mapValue.keys.toList()
+      ..removeWhere((k) => validKeys.contains(k));
+    if (invalidOptions.isNotEmpty) {
+      throw new ArgumentError('Got invalid options `$invalidOptions` for '
+          '$description. Only `$validKeys` are supported keys.');
+    }
+    return mapValue;
+  }
+
+  static String _readStringOrThrow(Map<String, dynamic> options, String option,
+      {String defaultValue, bool allowNull: false}) {
+    var value = options[option];
+    if (value == null && allowNull) return null;
+    if (value is! String) {
+      throw new ArgumentError(
+          'Expected a String for `$option` but got `$value`.');
+    }
+    return value;
+  }
+
+  static bool _readBoolOrThrow(Map<String, dynamic> options, String option,
+      {bool defaultValue}) {
+    var value = options[option] ?? defaultValue;
+    if (value is! bool) {
+      throw new ArgumentError(
+          'Expected a boolean for `$option` but got `$value`.');
+    }
+    return value;
   }
 }

--- a/lib/src/bazelify/bazelify_config.dart
+++ b/lib/src/bazelify/bazelify_config.dart
@@ -14,7 +14,6 @@ class BazelifyConfig {
   static const _vmPlatform = 'vm';
   static const _webPlatform = 'web';
 
-  /// Supported target config options.
   static const _targetOptions = const [
     _builders,
     _default,
@@ -32,7 +31,6 @@ class BazelifyConfig {
   static const _platforms = 'platforms';
   static const _sources = 'sources';
 
-  /// Supported builder config options.
   static const _builderOptions = const [
     _class,
     _constructor,
@@ -148,7 +146,8 @@ class BazelifyConfig {
           defaultValue: <String, dynamic>{});
 
       final clazz = _readStringOrThrow(builderConfig, _class);
-      final constructor = _readStringOrThrow(builderConfig, _constructor);
+      final constructor =
+          _readStringOrThrow(builderConfig, _constructor, allowNull: true);
       final import = _readStringOrThrow(builderConfig, _import);
       final inputExtension = _readStringOrThrow(builderConfig, _inputExtension);
       final outputExtensions =
@@ -156,8 +155,9 @@ class BazelifyConfig {
       final replacesTransformer = _readStringOrThrow(
           builderConfig, _replacesTransformer,
           allowNull: true);
-      final sharedPartOutput =
-          _readBoolOrThrow(builderConfig, _sharedPartOutput);
+      final sharedPartOutput = _readBoolOrThrow(
+          builderConfig, _sharedPartOutput,
+          defaultValue: false);
       final target = _readStringOrThrow(builderConfig, _target);
 
       dartBuilderBinaries[builderName] = new DartBuilderBinary(

--- a/test/bazelify_config_test.dart
+++ b/test/bazelify_config_test.dart
@@ -36,7 +36,7 @@ void main() {
       'h': new DartBuilderBinary(
         clazz: 'E',
         constructor: 'withSettings',
-        import: 'lib/e.dart',
+        import: 'package:example/e.dart',
         inputExtension: '.dart',
         name: 'h',
         outputExtensions: [
@@ -83,7 +83,7 @@ builders:
   h:
     class: E
     constructor: withSettings
-    import: lib/e.dart
+    import: package:example/e.dart
     input_extension: .dart
     output_extensions:
       - .g.dart

--- a/test/bazelify_config_test.dart
+++ b/test/bazelify_config_test.dart
@@ -10,18 +10,44 @@ void main() {
     var bazelifyConfig = new BazelifyConfig.parse(pubspec, bazelifyYaml);
     expectDartLibraries(bazelifyConfig.dartLibraries, {
       'a': new DartLibrary(
-          name: 'a',
-          package: 'example',
-          dependencies: ['b', 'c:d'],
-          sources: ['lib/a.dart', 'lib/src/a/**']),
+        builders: {
+          'b:b': {},
+          ':h': {'foo': 'bar'},
+        },
+        dependencies: ['b', 'c:d'],
+        generateFor: [
+          'lib/a.dart',
+        ],
+        name: 'a',
+        package: 'example',
+        sources: ['lib/a.dart', 'lib/src/a/**'],
+      ),
       'e': new DartLibrary(
-          name: 'e',
-          package: 'example',
-          dependencies: ['f', ':a'],
-          sources: ['lib/e.dart', 'lib/src/e/**'],
-          excludeSources: ['lib/src/e/g.dart'],
-          isDefault: true,
-          enableDdc: false),
+        dependencies: ['f', ':a'],
+        enableDdc: false,
+        excludeSources: ['lib/src/e/g.dart'],
+        isDefault: true,
+        name: 'e',
+        package: 'example',
+        sources: ['lib/e.dart', 'lib/src/e/**'],
+      )
+    });
+    expectDartBuilderBinaries(bazelifyConfig.dartBuilderBinaries, {
+      'h': new DartBuilderBinary(
+        clazz: 'E',
+        constructor: 'withSettings',
+        import: 'lib/e.dart',
+        inputExtension: '.dart',
+        name: 'h',
+        outputExtensions: [
+          '.g.dart',
+          '.json',
+        ],
+        package: 'example',
+        replacesTransformer: 'example',
+        sharedPartOutput: true,
+        target: 'e',
+      ),
     });
   });
 }
@@ -29,9 +55,15 @@ void main() {
 var bazelifyYaml = '''
 targets:
   a:
+    builders:
+      - :h:
+          foo: bar
+      - b:b
     dependencies:
       - b
       - c:d
+    generate_for:
+      - lib/a.dart
     sources:
       - "lib/a.dart"
       - "lib/src/a/**"
@@ -47,6 +79,18 @@ targets:
       - "lib/src/e/g.dart"
     platforms:
       - vm
+builders:
+  h:
+    class: E
+    constructor: withSettings
+    import: lib/e.dart
+    input_extension: .dart
+    output_extensions:
+      - .g.dart
+      - .json
+    replaces_transformer: example
+    shared_part_output: true
+    target: e
 ''';
 
 var pubspecYaml = '''
@@ -55,6 +99,38 @@ dependencies:
   a: 1.0.0
   b: 2.0.0
 ''';
+
+void expectDartBuilderBinaries(Map<String, DartBuilderBinary> actual,
+    Map<String, DartBuilderBinary> expected) {
+  expect(actual.keys, unorderedEquals(expected.keys));
+  for (var p in actual.keys) {
+    expect(actual[p], new _DartBuilderBinaryMatcher(expected[p]));
+  }
+}
+
+class _DartBuilderBinaryMatcher extends Matcher {
+  final DartBuilderBinary _expected;
+  _DartBuilderBinaryMatcher(this._expected);
+
+  @override
+  bool matches(item, _) =>
+      item is DartBuilderBinary &&
+      item.clazz == _expected.clazz &&
+      item.constructor == _expected.constructor &&
+      equals(_expected.dependencies).matches(item.dependencies, _) &&
+      item.inputExtension == _expected.inputExtension &&
+      item.import == _expected.import &&
+      item.name == _expected.name &&
+      equals(item.outputExtensions).matches(_expected.outputExtensions, _) &&
+      item.package == _expected.package &&
+      item.replacesTransformer == _expected.replacesTransformer &&
+      item.sharedPartOutput == _expected.sharedPartOutput &&
+      item.target == _expected.target;
+
+  @override
+  Description describe(Description description) =>
+      description.addDescriptionOf(_expected);
+}
 
 void expectDartLibraries(
     Map<String, DartLibrary> actual, Map<String, DartLibrary> expected) {
@@ -75,7 +151,9 @@ class _DartLibraryMatcher extends Matcher {
       item.package == _expected.package &&
       item.isDefault == _expected.isDefault &&
       item.enableDdc == _expected.enableDdc &&
+      equals(_expected.builders).matches(item.builders, _) &&
       equals(_expected.dependencies).matches(item.dependencies, _) &&
+      equals(_expected.generateFor).matches(item.generateFor, _) &&
       equals(_expected.sources).matches(item.sources, _) &&
       equals(_expected.excludeSources).matches(item.excludeSources, _);
 


### PR DESCRIPTION
Adds `builders` section to the config, and a `DartBuilderBinary` class (but `toRule` throws  an UnimplementedError today).

Also adds `builders` and `generate_for` values to `target` configs.

See `README.md` updates for further info.