### PR TITLE
Don't fail when an .analysis_options file is empty

### DIFF
--- a/lib/src/bazelify/bazelify_config.dart
+++ b/lib/src/bazelify/bazelify_config.dart
@@ -196,7 +196,7 @@ class BazelifyConfig {
         if (value.length == 1) {
           normalizedValues[value.keys.first] = value.values.first;
         } else {
-          throw value;
+          throw new ArgumentError('Expected single key but got $value');
         }
       } else {
         throw new ArgumentError(

--- a/lib/src/bazelify/build.dart
+++ b/lib/src/bazelify/build.dart
@@ -585,7 +585,7 @@ class DartBuilderBinary implements DartBuildRule {
   @override
   String toRule(Map<String, BazelifyConfig> bazelifyConfigs) =>
       throw new UnimplementedError(
-        '`builders` are not yet supported by bazelify');
+          '`builders` are not yet supported by bazelify');
 
   @override
   String toString() => 'clazz: $clazz\n'

--- a/lib/src/bazelify/initialize.dart
+++ b/lib/src/bazelify/initialize.dart
@@ -339,9 +339,15 @@ analyzer:
     } else {
       final analysisOptions =
           loadYaml(await analysisOptionsFile.readAsString());
-      final analyzerConfig = analysisOptions['analyzer'];
-      final excludes =
-          analyzerConfig == null ? null : analyzerConfig['exclude'];
+      final analyzerConfig = analysisOptions != null
+          ? analysisOptions['analyzer']
+          : const {
+              'strong-mode': true,
+              'exclude': const [
+                'bazel-*',
+              ],
+            };
+      final excludes = analyzerConfig['exclude'];
       if (excludes == null || !excludes.contains('bazel-*')) {
         print('Bazel will create directories with symlinked dart files which '
             'will impact the analysis server.\n'
@@ -354,7 +360,7 @@ analyzer:
     }
   }
 
-  /// Searchs up in directories starting with the pubPackageDir until a
+  /// Searches up in directories starting with the pubPackageDir until a
   /// '.analysis_options' or 'analysis_options.yaml' is found, or null if no
   /// such file exists.
   Future<File> _findAnalysisOptions() async {


### PR DESCRIPTION
Closes https://github.com/dart-lang/bazel/issues/75