### PR TITLE
Update to Build v0.7.0

### DIFF
--- a/bazel_codegen/lib/src/assets/asset_filter.dart
+++ b/bazel_codegen/lib/src/assets/asset_filter.dart
@@ -26,6 +26,6 @@ class AssetFilter {
       if (packagePath == null) return false;
       return _knownValidAssets.contains(p.join(packagePath, id.path));
     }
-    return !_assetWriter.assetsWritten.containsKey(id);
+    return !_assetWriter.assetsWritten.contains(id);
   }
 }

--- a/bazel_codegen/lib/src/assets/file_system.dart
+++ b/bazel_codegen/lib/src/assets/file_system.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
@@ -24,10 +25,17 @@ class BazelFileSystem {
   }
 
   //TODO(nbosch) replace with async version
-  String readAsStringSync(String path) {
+  List<int> readAsBytesSync(String path) =>
+      _fileForPath(path).readAsBytesSync();
+
+  //TODO(nbosch) replace with async version
+  String readAsStringSync(String path, {Encoding encoding: UTF8}) =>
+      _fileForPath(path).readAsStringSync(encoding: encoding ?? UTF8);
+
+  File _fileForPath(String path) {
     for (var searchPath in searchPaths) {
       var f = new File(p.join(workspaceDir, searchPath, path));
-      if (f.existsSync()) return f.readAsStringSync();
+      if (f.existsSync()) return f;
     }
     throw new FileSystemException('File not found', path);
   }

--- a/bazel_codegen/lib/src/run_phases.dart
+++ b/bazel_codegen/lib/src/run_phases.dart
@@ -157,15 +157,14 @@ Future<IOSinkLogHandle> _runBuilders(List<BuilderFactory> builders,
               () => runBuilder(builder, inputSrcs, reader, writer, resolvers,
                   logger: logger));
         }
-      },
-          zoneSpecification:
-              new ZoneSpecification(print: (self, parent, zone, message) {
-            if (isWorker) {
-              logger.info(message);
-            } else {
-              parent.print(zone, message);
-            }
-          }));
+      }, zoneSpecification:
+          new ZoneSpecification(print: (self, parent, zone, message) {
+        if (isWorker) {
+          logger.info(message);
+        } else {
+          parent.print(zone, message);
+        }
+      }));
     } catch (e, s) {
       logger.severe(
           'Caught error during code generation step '
@@ -174,18 +173,15 @@ Future<IOSinkLogHandle> _runBuilders(List<BuilderFactory> builders,
           s);
     }
 
-    // Avoid rereading from disk for previous outputs
-    reader.cacheAssets(writer.assetsWritten);
-
     // Set outputs as inputs into the next builder
     inputSrcs
       ..clear()
-      ..addAll(writer.assetsWritten.keys);
-    validInputs?.addAll(writer.assetsWritten.keys
+      ..addAll(writer.assetsWritten);
+    validInputs?.addAll(writer.assetsWritten
         .map((id) => p.join(packageMap[id.package], id.path)));
 
     // Track and clear written assets.
-    allWrittenAssets.addAll(writer.assetsWritten.keys);
+    allWrittenAssets.addAll(writer.assetsWritten);
     writer.assetsWritten.clear();
   }
 
@@ -203,8 +199,8 @@ Future<IOSinkLogHandle> _runBuilders(List<BuilderFactory> builders,
         if (allWrittenAssets.contains(expectedAssetId)) continue;
 
         if (defaultContent.containsKey(extension)) {
-          writes.add(writer.writeAsString(
-              new Asset(expectedAssetId, defaultContent[extension])));
+          writes.add(
+              writer.writeAsString(expectedAssetId, defaultContent[extension]));
         } else {
           logger.warning('Missing expected output $expectedAssetId');
         }

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -8,8 +8,8 @@ dependencies:
   analyzer: ^0.29.5
   args: ^0.13.6
   bazel_worker: ^0.1.2
-  build: ^0.6.3
-  build_barback: ^0.0.3
+  build: ^0.7.0
+  build_barback: ^0.1.0
   logging: ^0.11.3
   path: ^1.4.1
 


### PR DESCRIPTION
- Updates based on breaking changes in build
  - Resolver implementation adds isLibrary method and implemente
    ReleaseableResolver
  - Reader and writer get new bytes methods
  - assetsWritten works with AssetId rather than Asset
- Drop the asset cache in between builders. There is not much utility in
  it and it adds complexity
- Bump build_barback, no breaking changes that impact this package but
  necessary to use with the latest Build