### PR TITLE
Prefix external workspaces names with 'pub_'

### DIFF
--- a/dazel/lib/src/bazelify/build.dart
+++ b/dazel/lib/src/bazelify/build.dart
@@ -219,7 +219,7 @@ String depsToBazelTargetsString(Iterable<String> dependencies,
     if (package.isEmpty) {
       targets.add(':$target');
     } else {
-      targets.add('@$package//:$target');
+      targets.add('@pub_$package//:$target');
     }
   }
   return '[${targets.map((t) => '"$t"').join(',')}]';

--- a/dazel/lib/src/bazelify/initialize.dart
+++ b/dazel/lib/src/bazelify/initialize.dart
@@ -280,7 +280,7 @@ class _Initialize {
       Map<String, Pubspec> pubspecs,
       Map<String, BazelifyConfig> bazelifyConfigs) async {
     for (final package in packagePaths.keys) {
-      final buildFilePath = p.join(bazelifyPath, '$package.BUILD');
+      final buildFilePath = p.join(bazelifyPath, 'pub_$package.BUILD');
       final packageDir = packagePaths[package];
       var buildFile = await BuildFile.fromPackageDir(
           packageDir, pubspecs[package], bazelifyConfigs);

--- a/dazel/lib/src/bazelify/macro.dart
+++ b/dazel/lib/src/bazelify/macro.dart
@@ -13,9 +13,8 @@ class BazelMacroFile {
   ) {
     final repos = packages.map/*<NewLocalRepository>*/((d) {
       return new NewLocalRepository(
-        name: d,
+        name: 'pub_$d',
         path: resolvePath(d),
-        buildFile: '.dazel/$d.BUILD',
       );
     });
     return new BazelMacroFile.fromRepositories(
@@ -54,14 +53,10 @@ class NewLocalRepository {
   /// Local file path of the package.
   final String path;
 
-  /// Where the generated BUILD file should be.
-  final String buildFile;
-
   /// Create a `new_local_repository` macro.
   NewLocalRepository({
     this.name,
     this.path,
-    this.buildFile,
   });
 
   @override

--- a/dazel/test/bazel_macro_test.dart
+++ b/dazel/test/bazel_macro_test.dart
@@ -14,7 +14,6 @@ void main() {
         new NewLocalRepository(
           name: 'silly_monkey',
           path: 'some/path/to/.pub_cache/silly_monkey-0.0.0',
-          buildFile: '.dazel/silly_monkey.BUILD',
         )
             .toString(),
         'native.new_local_repository(\n'

--- a/dazel/test/goldens/build_file_library_with_deps
+++ b/dazel/test/goldens/build_file_library_with_deps
@@ -10,7 +10,7 @@ package(default_visibility = ["//visibility:public"])
 dart_library(
     name = "silly_monkey",
     srcs = glob(["lib/**"], exclude=[]),
-    deps = ["@path//:path"],
+    deps = ["@pub_path//:path"],
     enable_ddc = 1,
     pub_pkg_name = "silly_monkey",
 )

--- a/dazel/test/goldens/packages_bzl
+++ b/dazel/test/goldens/packages_bzl
@@ -6,7 +6,7 @@ PUB_PACKAGE_NAME = "silly_monkey"
 # Generated automatically for package:silly_monkey|pubspec.yaml
 def dazel_init():
     native.new_local_repository(
-        name = "path",
+        name = "pub_path",
         path = "some/path/to/.pub_cache/path-0.0.0",
-        build_file = ".dazel/path.BUILD",
+        build_file = ".dazel/pub_path.BUILD",
     )

--- a/tool/presubmit.dart
+++ b/tool/presubmit.dart
@@ -42,7 +42,7 @@ void testRunningGetCwd() {
 
 void testBuildingNg2App() {
   print('Building a Web app...');
-  var result = bazel(['build', 'ng2_app:all']);
+  var result = bazel(['build', ':ng2_app_run']);
   if (!result.stderr.contains('Compiling with dart2js //ng2_app:ng2_app')) {
     print('Error: ${result.stderr}');
     exit(1);


### PR DESCRIPTION
Fixes #97 

Pub packages are allowed to have names starting with underscore,
workspace names are not. Prefix all the local repositories with 'pub_'
to ensure they are valid.