### PR TITLE
Ignore missing entrypoints

### DIFF
--- a/dazel/lib/src/bazelify/build.dart
+++ b/dazel/lib/src/bazelify/build.dart
@@ -53,6 +53,7 @@ class BuildFile {
   static Stream<DartWebApplication> _findWebApps(
       String package, String packageDir, String searchDir) {
     return _findHtmlEntryPoints(packageDir, searchDir)
+        .where((entryPoint) => entryPoint != null)
         .map/*<DartWebApplication>*/((entryPoint) {
       return new DartWebApplication(
         name: p.withoutExtension(entryPoint.htmlFile),


### PR DESCRIPTION
If an .html file has no dart script tag don't consider it a web app.