### PR TITLE
Prepare for release as dazel

### DIFF
--- a/dazel/CHANGELOG.md
+++ b/dazel/CHANGELOG.md
@@ -1,5 +1,10 @@
-## 0.2.3
+## 0.3.0
 
+### Package rename
+
+* Previously this package was released as `bazel`. It's now called `dazel`
+
+### New features
 * Add `dazel build` command, which can build a web app and create a deployable
   directory for it (using dart2js), similar to `pub build`.
     * Has a single positional argument which should be the path to the html file

--- a/dazel/lib/src/bazelify/initialize.dart
+++ b/dazel/lib/src/bazelify/initialize.dart
@@ -139,7 +139,7 @@ class InitCommand extends Command {
 /// Where to retrieve the `rules_dart`.
 abstract class DartRulesSource {
   /// The default version of [DartRulesSource] if not otherwise specified.
-  static const DartRulesSource stable = const DartRulesSource.tag('v0.3.1');
+  static const DartRulesSource stable = const DartRulesSource.tag('v0.3.2');
 
   /// Use a git [commit].
   const factory DartRulesSource.commit(String commit) = _GitCommitRulesSource;

--- a/dazel/pubspec.yaml
+++ b/dazel/pubspec.yaml
@@ -2,7 +2,7 @@ name: dazel
 description: Bazel support for Dart
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/bazel
-version: 0.2.3
+version: 0.3.0
 
 # NOTE: We require a generated .packages file in order to use this package.
 environment:
@@ -18,8 +18,7 @@ dependencies:
   stack_trace: '^1.6.8'
   which: '^0.1.3'
   yaml: '^2.1.11'
-  _bazel_codegen:
-    path: ../bazel_codegen
+  _bazel_codegen: ^0.0.1
 
 dev_dependencies:
   path: "^1.4.0"


### PR DESCRIPTION
Latest rules dart supports the renamed _bazel_codegen and 'pub_'
prefixed repository names.