### PR TITLE
fix ddc rules, update to latest rules_dart

### DIFF
--- a/dazel/lib/src/bazelify/build.dart
+++ b/dazel/lib/src/bazelify/build.dart
@@ -6,6 +6,7 @@ import 'package:html/parser.dart' as html;
 import 'package:path/path.dart' as p;
 
 import 'bazelify_config.dart';
+import 'common.dart';
 import 'pubspec.dart';
 
 // These set of classes are specific to Bazelify and have limited use outside
@@ -56,7 +57,7 @@ class BuildFile {
     return _findHtmlEntryPoints(packageDir, searchDir)
         .map/*<DartWebApplication>*/((entryPoint) {
       return new DartWebApplication(
-        name: p.withoutExtension(entryPoint.htmlFile),
+        name: appPathToTarget(entryPoint.htmlFile),
         package: package,
         entryPoint: entryPoint,
       );
@@ -394,13 +395,16 @@ class DartWebApplication implements DartBuildRule {
 
   String get ddcBundleName => '${name}_ddc_bundle';
 
-  String get ddcBundleOutputHtmlPath => '$ddcBundleName.html';
+  String get ddcBundleOutputHtmlPath => '$outputDir/$ddcBundleName.html';
 
-  String get ddcServeName => '${name}_ddc_serve';
+  String get ddcServeName => ddcServeTarget(name);
 
   String get htmlFile => entryPoint.htmlFile;
 
-  String get packageSpecName => '${name}_ddc_bundle.packages';
+  // TODO: Update once we support apps outside of web.
+  String get outputDir => 'web';
+
+  String get packageSpecName => '$ddcBundleName.packages';
 
   String get scriptFile => entryPoint.dartFile;
 
@@ -437,7 +441,7 @@ class DartWebApplication implements DartBuildRule {
         '    entry_library = "$scriptFile",\n'
         '    entry_module = ":$package",\n'
         '    input_html = "$htmlFile",\n'
-        '    output_dir = "web",\n'
+        '    output_dir = "$outputDir",\n'
         ')\n';
     buffer += new DdcDevServer(name: ddcServeName, webApps: [this])
         .toRule(bazelifyConfigs);

--- a/dazel/lib/src/bazelify/build.dart
+++ b/dazel/lib/src/bazelify/build.dart
@@ -57,7 +57,7 @@ class BuildFile {
     return _findHtmlEntryPoints(packageDir, searchDir)
         .map/*<DartWebApplication>*/((entryPoint) {
       return new DartWebApplication(
-        name: appPathToTarget(entryPoint.htmlFile),
+        name: targetForAppPath(entryPoint.htmlFile),
         package: package,
         entryPoint: entryPoint,
       );

--- a/dazel/lib/src/bazelify/build_command.dart
+++ b/dazel/lib/src/bazelify/build_command.dart
@@ -43,7 +43,7 @@ class BuildCommand extends Command {
         outputDir: argResults['output-dir'],
         target: app);
 
-    await timer.run('Building app `${targetToAppPath(buildArgs.target)}`',
+    await timer.run('Building app `${appPathForTarget(buildArgs.target)}`',
         () => build(buildArgs),
         printCompleteOnNewLine: true);
     timer.complete(
@@ -96,7 +96,7 @@ class BuildCommand extends Command {
   }
 
   Future<HtmlEntryPoint> _getEntryPointData(String target) {
-    var file = new File(targetToAppPath(target));
+    var file = new File(appPathForTarget(target));
     return htmlEntryPointFromFile(file, './');
   }
 

--- a/dazel/lib/src/bazelify/common.dart
+++ b/dazel/lib/src/bazelify/common.dart
@@ -7,7 +7,6 @@ import 'package:path/path.dart' as p;
 
 import 'build.dart';
 
-/// Adds the `--app` argument to [argParser].
 void addAppArg(ArgParser argParser, {String defaultsTo}) {
   argParser.addOption('app',
       defaultsTo: defaultsTo,
@@ -38,7 +37,7 @@ String targetFromAppArgs(ArgResults argResults, ArgParser argParser,
         'Missing required argument `app`', argParser.usage);
   }
 
-  app = appPathToTarget(app);
+  app = targetForAppPath(app);
   // Slight hack here, we don't want to modify the general serve target which is
   // the default, it's already correct.
   if (ddc && app != BuildFile.ddcServeAllName) app = ddcServeTarget(app);
@@ -47,14 +46,14 @@ String targetFromAppArgs(ArgResults argResults, ArgParser argParser,
 }
 
 /// Returns the bazel target name given the path to an app (html file).
-String appPathToTarget(String appPath) {
+String targetForAppPath(String appPath) {
   // Target name doesn't have `.html`, but we want support for that for users.
   if (appPath.endsWith('.html')) appPath = p.withoutExtension(appPath);
   return p.split(appPath).join("__");
 }
 
 /// Returns the app path given a bazel target name.
-String targetToAppPath(String target) =>
+String appPathForTarget(String target) =>
     '${p.joinAll(target.split('__'))}.html';
 
 /// The name of the ddc server target corresponding to a web app target.

--- a/dazel/lib/src/bazelify/common.dart
+++ b/dazel/lib/src/bazelify/common.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'package:args/args.dart';
+import 'package:args/command_runner.dart';
+import 'package:path/path.dart' as p;
+
+import 'build.dart';
+
+/// Adds the `--app` argument to [argParser].
+void addAppArg(ArgParser argParser, {String defaultsTo}) {
+  argParser.addOption('app',
+      defaultsTo: defaultsTo,
+      help: 'The name of the app target to build, this is the name of the '
+          'html file for the app. This argument may be provided as a '
+          'positional argument as well.');
+}
+
+/// Returns the bazel target given the `--app` argument in [argResults], or
+/// uses the first extra argument if there is only one.
+///
+/// If [ddc] is `true` then the ddc server target will be returned, otherwise
+/// the dart application (dart2js) target is returned.
+///
+/// Throws a [UsageException] if a suitable argument cannot be found.
+String targetFromAppArgs(ArgResults argResults, ArgParser argParser,
+    {bool ddc: false}) {
+  var app;
+  // Support providing `app` as a positional argument (and overriding the
+  // default).
+  if (!argResults.wasParsed('app') && argResults.rest.length == 1) {
+    app = argResults.rest.first;
+  } else {
+    app = argResults['app'];
+  }
+  if (app == null) {
+    throw new UsageException(
+        'Missing required argument `app`', argParser.usage);
+  }
+
+  app = appPathToTarget(app);
+  // Slight hack here, we don't want to modify the general serve target which is
+  // the default, it's already correct.
+  if (ddc && app != BuildFile.ddcServeAllName) app = ddcServeTarget(app);
+
+  return app;
+}
+
+/// Returns the bazel target name given the path to an app (html file).
+String appPathToTarget(String appPath) {
+  // Target name doesn't have `.html`, but we want support for that for users.
+  if (appPath.endsWith('.html')) appPath = p.withoutExtension(appPath);
+  return p.split(appPath).join("__");
+}
+
+/// Returns the app path given a bazel target name.
+String targetToAppPath(String target) =>
+    '${p.joinAll(target.split('__'))}.html';
+
+/// The name of the ddc server target corresponding to a web app target.
+String ddcServeTarget(String webAppTarget) => '${webAppTarget}_ddc_serve';

--- a/dazel/lib/src/bazelify/initialize.dart
+++ b/dazel/lib/src/bazelify/initialize.dart
@@ -141,7 +141,7 @@ class InitCommand extends Command {
 /// Where to retrieve the `rules_dart`.
 abstract class DartRulesSource {
   /// The default version of [DartRulesSource] if not otherwise specified.
-  static const DartRulesSource stable = const DartRulesSource.tag('v0.3.2');
+  static const DartRulesSource stable = const DartRulesSource.tag('v0.4.0');
 
   /// Use a git [commit].
   const factory DartRulesSource.commit(String commit) = _GitCommitRulesSource;

--- a/dazel/lib/src/bazelify/serve.dart
+++ b/dazel/lib/src/bazelify/serve.dart
@@ -6,20 +6,17 @@ import 'package:path/path.dart' as p;
 
 import 'arguments.dart';
 import 'build.dart';
+import 'common.dart';
 import 'exceptions.dart';
 
 class ServeCommand extends Command {
   ServeCommand() {
-    argParser
-      ..addOption('watch',
-          allowMultiple: true,
-          defaultsTo: 'web,lib,pubspec.lock',
-          help: 'A list of files/directories to watch for changes and trigger '
-              ' builds')
-      ..addOption('target',
-          defaultsTo: '${BuildFile.ddcServeAllName}',
-          help: 'The name of the server build target to run.',
-          hide: true);
+    addAppArg(argParser, defaultsTo: BuildFile.ddcServeAllName);
+    argParser.addOption('watch',
+        allowMultiple: true,
+        defaultsTo: 'web,lib,pubspec.lock',
+        help: 'A list of files/directories to watch for changes and trigger '
+            ' builds');
   }
 
   @override
@@ -36,7 +33,7 @@ class ServeCommand extends Command {
     var serveArgs = new BazelifyServeArguments._(
         bazelExecutable: commonArgs.bazelExecutable,
         pubPackageDir: commonArgs.pubPackageDir,
-        target: argResults['target'],
+        target: targetFromAppArgs(argResults, argParser, ddc: true),
         watch: argResults != null ? argResults['watch'] as List<String> : null);
 
     await serve(serveArgs);

--- a/dazel/test/build_file_test.dart
+++ b/dazel/test/build_file_test.dart
@@ -55,7 +55,7 @@ void main() {
       'name: silly_monkey',
       webApps: [
         new DartWebApplication(
-          name: appPathToTarget('web/index.html'),
+          name: targetForAppPath('web/index.html'),
           package: 'silly_monkey',
           entryPoint: new HtmlEntryPoint(
               htmlFile: 'web/index.html', dartFile: 'web/main.dart'),
@@ -70,13 +70,13 @@ void main() {
       'name: silly_monkey',
       webApps: [
         new DartWebApplication(
-          name: appPathToTarget('web/main_web.html'),
+          name: targetForAppPath('web/main_web.html'),
           package: 'silly_monkey',
           entryPoint: new HtmlEntryPoint(
               htmlFile: 'web/index.html', dartFile: 'web/main.dart'),
         ),
         new DartWebApplication(
-          name: appPathToTarget('web/secondary_web.html'),
+          name: targetForAppPath('web/secondary_web.html'),
           package: 'silly_monkey',
           entryPoint: new HtmlEntryPoint(
               htmlFile: 'web/secondary.html', dartFile: 'web/secondary.dart'),

--- a/dazel/test/build_file_test.dart
+++ b/dazel/test/build_file_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:dazel/src/bazelify/bazelify_config.dart';
 import 'package:dazel/src/bazelify/build.dart';
+import 'package:dazel/src/bazelify/common.dart';
 import 'package:dazel/src/bazelify/pubspec.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -54,7 +55,7 @@ void main() {
       'name: silly_monkey',
       webApps: [
         new DartWebApplication(
-          name: 'web/index',
+          name: appPathToTarget('web/index.html'),
           package: 'silly_monkey',
           entryPoint: new HtmlEntryPoint(
               htmlFile: 'web/index.html', dartFile: 'web/main.dart'),
@@ -69,13 +70,13 @@ void main() {
       'name: silly_monkey',
       webApps: [
         new DartWebApplication(
-          name: 'web/main_web',
+          name: appPathToTarget('web/main_web.html'),
           package: 'silly_monkey',
           entryPoint: new HtmlEntryPoint(
               htmlFile: 'web/index.html', dartFile: 'web/main.dart'),
         ),
         new DartWebApplication(
-          name: 'web/secondary_web',
+          name: appPathToTarget('web/secondary_web.html'),
           package: 'silly_monkey',
           entryPoint: new HtmlEntryPoint(
               htmlFile: 'web/secondary.html', dartFile: 'web/secondary.dart'),

--- a/dazel/test/goldens/build_file_web_application
+++ b/dazel/test/goldens/build_file_web_application
@@ -24,7 +24,7 @@ dart_library(
 )
 # Generated automatically for package:silly_monkey|web/main.dart
 dart_web_application(
-    name = "web/index",
+    name = "web__index",
     srcs = glob(["web/**"], exclude=[]),
     script_file = "web/main.dart",
     deps = [] + [
@@ -32,32 +32,32 @@ dart_web_application(
     ],
 )
 dart_ddc_bundle(
-    name = "web/index_ddc_bundle",
+    name = "web__index_ddc_bundle",
     entry_library = "web/main.dart",
     entry_module = ":silly_monkey",
     input_html = "web/index.html",
     output_dir = "web",
 )
-# A ddc specific dev_server target which serves web/index
+# A ddc specific dev_server target which serves web__index
 dev_server(
-    name = "web/index_ddc_serve",
+    name = "web__index_ddc_serve",
     data = [
-        ":web/index_ddc_bundle",
+        ":web__index_ddc_bundle",
     ],
     script_args = [
-        "--package-spec=web/index_ddc_bundle.packages",
-        "--uri-substitution=web/index.html:web/index_ddc_bundle.html",
+        "--package-spec=web__index_ddc_bundle.packages",
+        "--uri-substitution=web/index.html:web/web__index_ddc_bundle.html",
     ],
 )
 
-# A ddc specific dev_server target which serves web/index
+# A ddc specific dev_server target which serves web__index
 dev_server(
     name = "__ddc_serve_all",
     data = [
-        ":web/index_ddc_bundle",
+        ":web__index_ddc_bundle",
     ],
     script_args = [
-        "--package-spec=web/index_ddc_bundle.packages",
-        "--uri-substitution=web/index.html:web/index_ddc_bundle.html",
+        "--package-spec=web__index_ddc_bundle.packages",
+        "--uri-substitution=web/index.html:web/web__index_ddc_bundle.html",
     ],
 )

--- a/dazel/test/goldens/build_file_web_application_multi
+++ b/dazel/test/goldens/build_file_web_application_multi
@@ -24,7 +24,7 @@ dart_library(
 )
 # Generated automatically for package:silly_monkey|web/main.dart
 dart_web_application(
-    name = "web/main_web",
+    name = "web__main_web",
     srcs = glob(["web/**"], exclude=[]),
     script_file = "web/main.dart",
     deps = [] + [
@@ -32,27 +32,27 @@ dart_web_application(
     ],
 )
 dart_ddc_bundle(
-    name = "web/main_web_ddc_bundle",
+    name = "web__main_web_ddc_bundle",
     entry_library = "web/main.dart",
     entry_module = ":silly_monkey",
     input_html = "web/index.html",
     output_dir = "web",
 )
-# A ddc specific dev_server target which serves web/main_web
+# A ddc specific dev_server target which serves web__main_web
 dev_server(
-    name = "web/main_web_ddc_serve",
+    name = "web__main_web_ddc_serve",
     data = [
-        ":web/main_web_ddc_bundle",
+        ":web__main_web_ddc_bundle",
     ],
     script_args = [
-        "--package-spec=web/main_web_ddc_bundle.packages",
-        "--uri-substitution=web/index.html:web/main_web_ddc_bundle.html",
+        "--package-spec=web__main_web_ddc_bundle.packages",
+        "--uri-substitution=web/index.html:web/web__main_web_ddc_bundle.html",
     ],
 )
 
 # Generated automatically for package:silly_monkey|web/secondary.dart
 dart_web_application(
-    name = "web/secondary_web",
+    name = "web__secondary_web",
     srcs = glob(["web/**"], exclude=[]),
     script_file = "web/secondary.dart",
     deps = [] + [
@@ -60,34 +60,34 @@ dart_web_application(
     ],
 )
 dart_ddc_bundle(
-    name = "web/secondary_web_ddc_bundle",
+    name = "web__secondary_web_ddc_bundle",
     entry_library = "web/secondary.dart",
     entry_module = ":silly_monkey",
     input_html = "web/secondary.html",
     output_dir = "web",
 )
-# A ddc specific dev_server target which serves web/secondary_web
+# A ddc specific dev_server target which serves web__secondary_web
 dev_server(
-    name = "web/secondary_web_ddc_serve",
+    name = "web__secondary_web_ddc_serve",
     data = [
-        ":web/secondary_web_ddc_bundle",
+        ":web__secondary_web_ddc_bundle",
     ],
     script_args = [
-        "--package-spec=web/secondary_web_ddc_bundle.packages",
-        "--uri-substitution=web/secondary.html:web/secondary_web_ddc_bundle.html",
+        "--package-spec=web__secondary_web_ddc_bundle.packages",
+        "--uri-substitution=web/secondary.html:web/web__secondary_web_ddc_bundle.html",
     ],
 )
 
-# A ddc specific dev_server target which serves web/main_web, web/secondary_web
+# A ddc specific dev_server target which serves web__main_web, web__secondary_web
 dev_server(
     name = "__ddc_serve_all",
     data = [
-        ":web/main_web_ddc_bundle",
-        ":web/secondary_web_ddc_bundle",
+        ":web__main_web_ddc_bundle",
+        ":web__secondary_web_ddc_bundle",
     ],
     script_args = [
-        "--package-spec=web/main_web_ddc_bundle.packages",
-        "--uri-substitution=web/index.html:web/main_web_ddc_bundle.html",
-        "--uri-substitution=web/secondary.html:web/secondary_web_ddc_bundle.html",
+        "--package-spec=web__main_web_ddc_bundle.packages",
+        "--uri-substitution=web/index.html:web/web__main_web_ddc_bundle.html",
+        "--uri-substitution=web/secondary.html:web/web__secondary_web_ddc_bundle.html",
     ],
 )


### PR DESCRIPTION
Target names no longer have slashes, instead we replace them with a double underscore. Users still supply normal paths on the command line though so that bash completion etc work.

Fixes https://github.com/dart-lang/bazel/issues/124