### PR TITLE
Await a Future direcly rather than a completer

### DIFF
--- a/bazel_codegen/CHANGELOG.md
+++ b/bazel_codegen/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.0.3-dev
+
+- Fix a bug where failure to read an asset during the Resolvers.get call would
+  cause the entire process to hang.
+
 # 0.0.2
 
 - Bug fix: Correct the import after library was renamed with a leading

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -2,7 +2,7 @@ name: _bazel_codegen
 description: Bazel code generation runner
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/bazel
-version: 0.0.2
+version: 0.0.3-dev
 
 environment:
   sdk: ">=1.8.0 <2.0.0"


### PR DESCRIPTION
If the priming process threw an exception the Completer would never
complete which caused the overall process to get killed and fail to
create outputs.

- Avoid a Completer and the Future from an async method directly
- Use ??= to assign a Future field which ensures the single-entry
  behavior we had before