### PR TITLE
Only read assets that end in .dart in the Resolver

### DIFF
--- a/bazel_codegen/CHANGELOG.md
+++ b/bazel_codegen/CHANGELOG.md
@@ -1,5 +1,8 @@
-# 0.0.3-dev
+# 0.0.3
 
+- Only read '.dart' files as sources for the Resolver. This avoids a problem
+  trying to read binary assets as if they were strings. Poorly encoded .dart
+  files can still cause an error - but this case we'd expect to fail.
 - Fix a bug where failure to read an asset during the Resolvers.get call would
   cause the entire process to hang.
 

--- a/bazel_codegen/lib/src/summaries/build_asset_uri_resolver.dart
+++ b/bazel_codegen/lib/src/summaries/build_asset_uri_resolver.dart
@@ -17,10 +17,10 @@ typedef Future<String> ReadAsset(AssetId assetId);
 class BuildAssetUriResolver implements UriResolver {
   final _knownAssets = <Uri, Source>{};
 
-  /// Read all [assets] using the [read] function up front and cache them as a
-  /// [Source].
+  /// Read all [assets] with the extension '.dart' using the [read] function up
+  /// front and cache them as a [Source].
   Future<Null> addAssets(Iterable<AssetId> assets, ReadAsset read) async {
-    for (var asset in assets) {
+    for (var asset in assets.where((asset) => asset.path.endsWith('.dart'))) {
       var uri = assetUri(asset);
       if (!_knownAssets.containsKey(uri)) {
         _knownAssets[uri] = new AssetSource(asset, await read(asset));

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -2,7 +2,7 @@ name: _bazel_codegen
 description: Bazel code generation runner
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/bazel
-version: 0.0.3-dev
+version: 0.0.3
 
 environment:
   sdk: ">=1.8.0 <2.0.0"


### PR DESCRIPTION
Avoids a bug where we can't get a Resolver if there are any binay assets
(that don't end in .dart) as inputs.