### PR TITLE
Rename BazelifyConfig -> BuildConfig

### DIFF
--- a/dazel/lib/src/bazelify/build.dart
+++ b/dazel/lib/src/bazelify/build.dart
@@ -5,7 +5,7 @@ import 'package:html/dom.dart' as dom;
 import 'package:html/parser.dart' as html;
 import 'package:path/path.dart' as p;
 
-import 'bazelify_config.dart';
+import '../config/build_config.dart';
 import 'common.dart';
 import 'pubspec.dart';
 
@@ -72,19 +72,19 @@ class BuildFile {
   static const _vmBzl = '$_rulesSource:vm.bzl';
 
   /// The parsed `build.yaml` file.
-  final BazelifyConfig bazelifyConfig;
+  final BuildConfig buildConfig;
 
-  /// All the `BazelifyConfig`s that are known, by package name.
-  final Map<String, BazelifyConfig> bazelifyConfigs;
+  /// All the `BuildConfig`s that are known, by package name.
+  final Map<String, BuildConfig> buildConfigs;
 
   /// Dart libraries.
-  Iterable<DartLibrary> get libraries => bazelifyConfig.dartLibraries.values;
+  Iterable<DartLibrary> get libraries => buildConfig.dartLibraries.values;
 
   /// Dart VM binaries.
   final List<DartVmBinary> binaries;
 
   Iterable<DartBuilderBinary> get builderBinaries =>
-      bazelifyConfig.dartBuilderBinaries.values;
+      buildConfig.dartBuilderBinaries.values;
 
   /// Dart web applications.
   final List<DartWebApplication> webApplications;
@@ -95,10 +95,10 @@ class BuildFile {
   /// - Every package generates one or more dart_libraries
   /// - Some packages generate 1 or more dart_vm_binary or dart_web_application
   ///
-  /// A `BazelifyConfig` will also be created, and added to `bazelifyConfigs`.
+  /// A `BuildConfig` will also be created, and added to `buildConfigs`.
   static Future<BuildFile> fromPackageDir(String packageDir, Pubspec pubspec,
-      Map<String, BazelifyConfig> bazelifyConfigs) async {
-    final bazelifyConfig = bazelifyConfigs[pubspec.pubPackageName];
+      Map<String, BuildConfig> buildConfigs) async {
+    final buildConfig = buildConfigs[pubspec.pubPackageName];
 
     final binDir = new Directory(p.join(packageDir, 'bin'));
     final webDir = new Directory(p.join(packageDir, 'web'));
@@ -114,8 +114,8 @@ class BuildFile {
               .toList();
     }
     return new BuildFile(
-      bazelifyConfig,
-      bazelifyConfigs,
+      buildConfig,
+      buildConfigs,
       binaries: binaries,
       webApps: webApps,
     );
@@ -123,8 +123,8 @@ class BuildFile {
 
   /// Creates a new [BuildFile].
   BuildFile(
-    this.bazelifyConfig,
-    this.bazelifyConfigs, {
+    this.buildConfig,
+    this.buildConfigs, {
     Iterable<DartVmBinary> binaries: const [],
     Iterable<DartWebApplication> webApps: const [],
   })
@@ -165,7 +165,7 @@ class BuildFile {
     final buildersUsed =
         libraries.expand((l) => l.builders?.keys ?? const <String>[]);
     for (var builder in buildersUsed) {
-      var builderDefinition = bazelifyConfigs.values
+      var builderDefinition = buildConfigs.values
           .expand((c) => c.dartBuilderBinaries.values)
           .firstWhere((b) => b.name == builder);
       var builderPackage = builderDefinition.package;
@@ -181,28 +181,28 @@ class BuildFile {
 
     // Now, define some build rules.
     libraries
-        .map/*<String>*/((r) => r.toRule(bazelifyConfigs))
+        .map/*<String>*/((r) => r.toRule(buildConfigs))
         .forEach(buffer.writeln);
     webApplications
         .map/*<String>*/(
-            (r) => r.toRule(bazelifyConfigs, includeLibraries: libraries))
+            (r) => r.toRule(buildConfigs, includeLibraries: libraries))
         .forEach(buffer.writeln);
 
     // The general dev server target.
     if (webApplications.isNotEmpty) {
       buffer.writeln(
           new DdcDevServer(name: ddcServeAllName, webApps: webApplications)
-              .toRule(bazelifyConfigs));
+              .toRule(buildConfigs));
     }
 
     binaries
         .map/*<String>*/(
-            (r) => r.toRule(bazelifyConfigs, includeLibraries: libraries))
+            (r) => r.toRule(buildConfigs, includeLibraries: libraries))
         .forEach(buffer.writeln);
 
     // Note: This will throw today.
     builderBinaries
-        .map/*<String>*/((r) => r.toRule(bazelifyConfigs))
+        .map/*<String>*/((r) => r.toRule(buildConfigs))
         .forEach(buffer.writeln);
 
     return buffer.toString();
@@ -210,10 +210,10 @@ class BuildFile {
 }
 
 /// Returns a `String` representing the list of bazel targets from
-/// `dependencies` using `bazelifyConfigs` to find default target names when not
+/// `dependencies` using `buildConfigs` to find default target names when not
 /// supplied explicitly.
 String depsToBazelTargetsString(Iterable<String> dependencies,
-    Map<String, BazelifyConfig> bazelifyConfigs) {
+    Map<String, BuildConfig> buildConfigs) {
   var targets = new Set<String>();
   for (var dep in dependencies) {
     var parts = dep.split(':');
@@ -224,7 +224,7 @@ String depsToBazelTargetsString(Iterable<String> dependencies,
     var package = parts[0];
     var target = parts.length > 1
         ? parts[1]
-        : bazelifyConfigs[package].defaultDartLibrary.name;
+        : buildConfigs[package].defaultDartLibrary.name;
     if (package.isEmpty) {
       targets.add(':$target');
     } else {
@@ -253,7 +253,7 @@ abstract class DartBuildRule {
   Iterable<String> get sources;
 
   /// Convert to a dart_rule(...) string.
-  String toRule(Map<String, BazelifyConfig> bazelifyConfigs);
+  String toRule(Map<String, BuildConfig> buildConfigs);
 }
 
 /// A `dart_library` definition.
@@ -301,7 +301,7 @@ class DartLibrary implements DartBuildRule {
       this.sources: const ['lib/**']});
 
   @override
-  String toRule(Map<String, BazelifyConfig> bazelifyConfigs) {
+  String toRule(Map<String, BuildConfig> buildConfigs) {
     var rule = new StringBuffer();
     var generatedTargets = <String>[];
     for (var builderName in builders.keys) {
@@ -321,7 +321,7 @@ class DartLibrary implements DartBuildRule {
         ? ''
         : ' + [${generatedTargets.map((t) => '":$t"').join(', ')}]';
     var srcs = _sourcesToGlob(sources, excludeSources);
-    var deps = depsToBazelTargetsString(dependencies, bazelifyConfigs);
+    var deps = depsToBazelTargetsString(dependencies, buildConfigs);
     rule
       ..writeln('# Generated automatically for package:$package')
       ..writeln('dart_library(')
@@ -376,7 +376,7 @@ class DartVmBinary implements DartBuildRule {
       this.sources: const ['bin/**']});
 
   @override
-  String toRule(Map<String, BazelifyConfig> bazelifyConfigs,
+  String toRule(Map<String, BuildConfig> buildConfigs,
       {Iterable<DartLibrary> includeLibraries: const []}) {
     String buffer =
         '# Generated automatically for package:$package|$scriptFile\n'
@@ -384,7 +384,7 @@ class DartVmBinary implements DartBuildRule {
         '    name = "$name",\n'
         '    srcs = ${_sourcesToGlob(sources, excludeSources)},\n'
         '    script_file = "$scriptFile",\n'
-        '    deps = ${depsToBazelTargetsString(dependencies, bazelifyConfigs)}';
+        '    deps = ${depsToBazelTargetsString(dependencies, buildConfigs)}';
     if (includeLibraries.isEmpty) {
       return '$buffer,\n)';
     } else {
@@ -443,7 +443,7 @@ class DartWebApplication implements DartBuildRule {
       this.entryPoint});
 
   @override
-  String toRule(Map<String, BazelifyConfig> bazelifyConfigs,
+  String toRule(Map<String, BuildConfig> buildConfigs,
       {Iterable<DartLibrary> includeLibraries: const []}) {
     String buffer =
         '# Generated automatically for package:$package|$scriptFile\n'
@@ -451,7 +451,7 @@ class DartWebApplication implements DartBuildRule {
         '    name = "$name",\n'
         '    srcs = ${_sourcesToGlob(sources, excludeSources)},\n'
         '    script_file = "$scriptFile",\n'
-        '    deps = ${depsToBazelTargetsString(dependencies, bazelifyConfigs)}';
+        '    deps = ${depsToBazelTargetsString(dependencies, buildConfigs)}';
     if (includeLibraries.isEmpty) {
       buffer = '$buffer,\n)';
     } else {
@@ -469,7 +469,7 @@ class DartWebApplication implements DartBuildRule {
         '    output_dir = "$outputDir",\n'
         ')\n';
     buffer += new DdcDevServer(name: ddcServeName, webApps: [this])
-        .toRule(bazelifyConfigs);
+        .toRule(buildConfigs);
     buffer += '\n';
     return buffer;
   }
@@ -591,7 +591,7 @@ class DartBuilderBinary implements DartBuildRule {
       this.target});
 
   @override
-  String toRule(Map<String, BazelifyConfig> bazelifyConfigs) =>
+  String toRule(Map<String, BuildConfig> buildConfigs) =>
       'dart_codegen_binary(\n'
       '    name = "$name",\n'
       '    srcs = [],\n'

--- a/dazel/lib/src/bazelify/build.dart
+++ b/dazel/lib/src/bazelify/build.dart
@@ -212,8 +212,8 @@ class BuildFile {
 /// Returns a `String` representing the list of bazel targets from
 /// `dependencies` using `buildConfigs` to find default target names when not
 /// supplied explicitly.
-String depsToBazelTargetsString(Iterable<String> dependencies,
-    Map<String, BuildConfig> buildConfigs) {
+String depsToBazelTargetsString(
+    Iterable<String> dependencies, Map<String, BuildConfig> buildConfigs) {
   var targets = new Set<String>();
   for (var dep in dependencies) {
     var parts = dep.split(':');

--- a/dazel/lib/src/bazelify/initialize.dart
+++ b/dazel/lib/src/bazelify/initialize.dart
@@ -323,12 +323,11 @@ class _Initialize {
     await new File(workspaceFile).writeAsString('$workspace');
   }
 
-  Future<Null> _writeBuildFile(
-      Map<String, BuildConfig> buildConfigs) async {
+  Future<Null> _writeBuildFile(Map<String, BuildConfig> buildConfigs) async {
     final packagePath = arguments.pubPackageDir;
     final pubspec = await Pubspec.fromPackageDir(packagePath);
-    final buildConfig = await BuildConfig
-        .fromPackageDir(pubspec, packagePath, includeWebSources: true);
+    final buildConfig = await BuildConfig.fromPackageDir(pubspec, packagePath,
+        includeWebSources: true);
     buildConfigs[pubspec.pubPackageName] = buildConfig;
     final rootBuild = await BuildFile.fromPackageDir(
         arguments.pubPackageDir, pubspec, buildConfigs);

--- a/dazel/lib/src/config/build_config.dart
+++ b/dazel/lib/src/config/build_config.dart
@@ -4,11 +4,11 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
-import 'build.dart';
-import 'pubspec.dart';
+import '../bazelify/build.dart';
+import '../bazelify/pubspec.dart';
 
 /// The parsed values from a `build.yaml` file.
-class BazelifyConfig {
+class BuildConfig {
   /// Supported values for the `platforms` attribute.
   static const _allPlatforms = const [_vmPlatform, _webPlatform];
   static const _vmPlatform = 'vm';
@@ -46,18 +46,18 @@ class BazelifyConfig {
   static const _replacesTransformer = 'replaces_transformer';
   static const _target = 'target';
 
-  /// Returns a parsed [BazelifyConfig] file in [path], if one exists.
+  /// Returns a parsed [BuildConfig] file in [path], if one exists.
   ///
   /// Otherwise uses the default setup.
-  static Future<BazelifyConfig> fromPackageDir(Pubspec pubspec, String path,
+  static Future<BuildConfig> fromPackageDir(Pubspec pubspec, String path,
       {bool includeWebSources: false}) async {
     final configPath = p.join(path, 'build.yaml');
     final file = new File(configPath);
     if (await file.exists()) {
-      return new BazelifyConfig.parse(pubspec, await file.readAsString(),
+      return new BuildConfig.parse(pubspec, await file.readAsString(),
           includeWebSources: includeWebSources);
     } else {
-      return new BazelifyConfig.useDefault(pubspec,
+      return new BuildConfig.useDefault(pubspec,
           includeWebSources: includeWebSources);
     }
   }
@@ -69,7 +69,7 @@ class BazelifyConfig {
   final dartLibraries = <String, DartLibrary>{};
 
   /// The default config if you have no `build.yaml` file.
-  BazelifyConfig.useDefault(Pubspec pubspec,
+  BuildConfig.useDefault(Pubspec pubspec,
       {bool includeWebSources: false,
       bool enableDdc: true,
       Iterable<String> excludeSources: const []}) {
@@ -86,8 +86,8 @@ class BazelifyConfig {
         excludeSources: excludeSources);
   }
 
-  /// Create a [BazelifyConfig] by parsing [configYaml].
-  BazelifyConfig.parse(Pubspec pubspec, String configYaml,
+  /// Create a [BuildConfig] by parsing [configYaml].
+  BuildConfig.parse(Pubspec pubspec, String configYaml,
       {bool includeWebSources: false}) {
     final config = loadYaml(configYaml);
 

--- a/dazel/test/bazelify_config_test.dart
+++ b/dazel/test/bazelify_config_test.dart
@@ -1,14 +1,14 @@
 import 'package:test/test.dart';
 
-import 'package:dazel/src/bazelify/bazelify_config.dart';
 import 'package:dazel/src/bazelify/build.dart';
 import 'package:dazel/src/bazelify/pubspec.dart';
+import 'package:dazel/src/config/build_config.dart';
 
 void main() {
   test('build.yaml can be parsed', () {
     var pubspec = new Pubspec.parse(pubspecYaml);
-    var bazelifyConfig = new BazelifyConfig.parse(pubspec, buildYaml);
-    expectDartLibraries(bazelifyConfig.dartLibraries, {
+    var buildConfig = new BuildConfig.parse(pubspec, buildYaml);
+    expectDartLibraries(buildConfig.dartLibraries, {
       'a': new DartLibrary(
         builders: {
           'b:b': {},
@@ -32,7 +32,7 @@ void main() {
         sources: ['lib/e.dart', 'lib/src/e/**'],
       )
     });
-    expectDartBuilderBinaries(bazelifyConfig.dartBuilderBinaries, {
+    expectDartBuilderBinaries(buildConfig.dartBuilderBinaries, {
       'h': new DartBuilderBinary(
         builderFactories: ['createBuilder'],
         import: 'package:example/e.dart',
@@ -51,8 +51,8 @@ void main() {
 
   test('build.yaml can omit a targets section', () {
     var pubspec = new Pubspec.parse(pubspecYaml);
-    var bazelifyConfig = new BazelifyConfig.parse(pubspec, buildYamlNoTargets);
-    expectDartLibraries(bazelifyConfig.dartLibraries, {
+    var buildConfig = new BuildConfig.parse(pubspec, buildYamlNoTargets);
+    expectDartLibraries(buildConfig.dartLibraries, {
       'example': new DartLibrary(
         dependencies: ['a', 'b'],
         isDefault: true,
@@ -61,7 +61,7 @@ void main() {
         sources: ['lib/**'],
       ),
     });
-    expectDartBuilderBinaries(bazelifyConfig.dartBuilderBinaries, {
+    expectDartBuilderBinaries(buildConfig.dartBuilderBinaries, {
       'a': new DartBuilderBinary(
         builderFactories: ['createBuilder'],
         import: 'package:example/builder.dart',

--- a/dazel/test/build_file_test.dart
+++ b/dazel/test/build_file_test.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:dazel/src/bazelify/bazelify_config.dart';
 import 'package:dazel/src/bazelify/build.dart';
 import 'package:dazel/src/bazelify/common.dart';
 import 'package:dazel/src/bazelify/pubspec.dart';
+import 'package:dazel/src/config/build_config.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -16,11 +16,11 @@ void main() {
   BuildFile createBuildFile(String pubspecYaml,
       {bool enableDdc: true,
       Iterable<String> excludeSources: const [],
-      Map<String, BazelifyConfig> extraConfigs: const {},
+      Map<String, BuildConfig> extraConfigs: const {},
       Iterable<DartWebApplication> webApps: const [],
       Iterable<DartVmBinary> binaries: const []}) {
     final pubspec = new Pubspec.parse(pubspecYaml);
-    final bazelConfig = new BazelifyConfig.useDefault(pubspec,
+    final bazelConfig = new BuildConfig.useDefault(pubspec,
         enableDdc: enableDdc,
         excludeSources: excludeSources,
         includeWebSources: webApps.isNotEmpty);
@@ -38,9 +38,9 @@ void main() {
 
   test('should generate a simple library with dependencies', () {
     final pathPubspec = new Pubspec.parse('name: path');
-    final pathBazelifyConfig = new BazelifyConfig.useDefault(pathPubspec);
+    final pathBuildConfig = new BuildConfig.useDefault(pathPubspec);
     final extraConfigs = {
-      pathPubspec.pubPackageName: pathBazelifyConfig,
+      pathPubspec.pubPackageName: pathBuildConfig,
     };
     final yaml = '''
         name: silly_monkey
@@ -104,17 +104,17 @@ void main() {
 
   group('fromPackageDir', () {
     Future<BuildFile> loadBuildFileFromDir(String packageDir,
-        {Map<String, BazelifyConfig> extraConfigs: const {},
+        {Map<String, BuildConfig> extraConfigs: const {},
         bool includeWebSources: false}) async {
       packageDir = p.normalize(packageDir);
       final pubspec = await Pubspec.fromPackageDir(packageDir);
-      final bazelifyConfig = await BazelifyConfig.fromPackageDir(
+      final buildConfig = await BuildConfig.fromPackageDir(
           pubspec, packageDir,
           includeWebSources: includeWebSources);
-      final bazelifyConfigs = {
-        pubspec.pubPackageName: bazelifyConfig,
+      final buildConfigs = {
+        pubspec.pubPackageName: buildConfig,
       }..addAll(extraConfigs);
-      return BuildFile.fromPackageDir(packageDir, pubspec, bazelifyConfigs);
+      return BuildFile.fromPackageDir(packageDir, pubspec, buildConfigs);
     }
 
     test('should generate a simple library with no dependencies', () async {
@@ -124,9 +124,9 @@ void main() {
 
     test('should generate a simple library with dependencies', () async {
       final pathPubspec = new Pubspec.parse('name: path');
-      final pathBazelifyConfig = new BazelifyConfig.useDefault(pathPubspec);
+      final pathBuildConfig = new BuildConfig.useDefault(pathPubspec);
       var extraConfigs = {
-        pathPubspec.pubPackageName: pathBazelifyConfig,
+        pathPubspec.pubPackageName: pathBuildConfig,
       };
       final build = await loadBuildFileFromDir('test/projects/simple_with_deps',
           extraConfigs: extraConfigs);
@@ -159,7 +159,7 @@ void main() {
       final codegenAuthorPath = 'test/projects/codegen_author';
       final codegenAuthorPubspec =
           await Pubspec.fromPackageDir(codegenAuthorPath);
-      final codegenAuthorConfig = await BazelifyConfig.fromPackageDir(
+      final codegenAuthorConfig = await BuildConfig.fromPackageDir(
           codegenAuthorPubspec, codegenAuthorPath);
       final extraConfigs = {'codegen_author': codegenAuthorConfig};
       final build = await loadBuildFileFromDir('test/projects/codegen_consumer',

--- a/dazel/test/codegen_file_test.dart
+++ b/dazel/test/codegen_file_test.dart
@@ -4,9 +4,9 @@
 
 import 'dart:io';
 
-import 'package:dazel/src/bazelify/bazelify_config.dart';
 import 'package:dazel/src/bazelify/codegen_rules.dart';
 import 'package:dazel/src/bazelify/pubspec.dart';
+import 'package:dazel/src/config/build_config.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -19,7 +19,7 @@ void main() {
     final codegenAuthorPath = 'test/projects/codegen_author';
     final codegenAuthorPubspec =
         await Pubspec.fromPackageDir(codegenAuthorPath);
-    final codegenAuthorConfig = await BazelifyConfig.fromPackageDir(
+    final codegenAuthorConfig = await BuildConfig.fromPackageDir(
         codegenAuthorPubspec, codegenAuthorPath);
     final codegenRules =
         new CodegenRulesFile(codegenAuthorConfig.dartBuilderBinaries);


### PR DESCRIPTION
Start dropping the `bazelify` name piece by piece rather than in one
huge diff.

- Make a `config` directory under `src` - will start moving to slightly
  more targeted directories and will be expanding config
- Rename BazelifyConfig to BuildConfig and relevant variable name
  changes
- Update imports