### PR TITLE
Pull out a BuildConfigSet

### DIFF
--- a/dazel/lib/src/bazelify/build.dart
+++ b/dazel/lib/src/bazelify/build.dart
@@ -72,12 +72,11 @@ class BuildFile {
   static const _webBzl = '$_rulesSource:web.bzl';
   static const _vmBzl = '$_rulesSource:vm.bzl';
 
-  final String packageName;
+  /// The [BuildConfig] for this specific package.
+  final BuildConfig buildConfig;
 
   /// All the `BuildConfig`s that are known, by package name.
   final BuildConfigSet buildConfigs;
-
-  BuildConfig get buildConfig => buildConfigs.dependencies[packageName];
 
   /// Dart libraries.
   Iterable<DartLibrary> get libraries => buildConfig.dartLibraries.values;
@@ -98,6 +97,11 @@ class BuildFile {
   /// - Some packages generate 1 or more dart_vm_binary or dart_web_application
   static Future<BuildFile> fromPackageDir(
       String packageDir, Pubspec pubspec, BuildConfigSet buildConfigs) async {
+    final packageName = pubspec.pubPackageName;
+    final buildConfig = buildConfigs.local.packageName == packageName
+        ? buildConfigs.local
+        : buildConfigs.dependencies[packageName];
+
     final binDir = new Directory(p.join(packageDir, 'bin'));
     final webDir = new Directory(p.join(packageDir, 'web'));
     Iterable<DartVmBinary> binaries = const [];
@@ -112,7 +116,7 @@ class BuildFile {
               .toList();
     }
     return new BuildFile(
-      pubspec.pubPackageName,
+      buildConfig,
       buildConfigs,
       binaries: binaries,
       webApps: webApps,
@@ -121,7 +125,7 @@ class BuildFile {
 
   /// Creates a new [BuildFile].
   BuildFile(
-    this.packageName,
+    this.buildConfig,
     this.buildConfigs, {
     Iterable<DartVmBinary> binaries: const [],
     Iterable<DartWebApplication> webApps: const [],

--- a/dazel/lib/src/bazelify/build.dart
+++ b/dazel/lib/src/bazelify/build.dart
@@ -97,10 +97,7 @@ class BuildFile {
   /// - Some packages generate 1 or more dart_vm_binary or dart_web_application
   static Future<BuildFile> fromPackageDir(
       String packageDir, Pubspec pubspec, BuildConfigSet buildConfigs) async {
-    final packageName = pubspec.pubPackageName;
-    final buildConfig = buildConfigs.local.packageName == packageName
-        ? buildConfigs.local
-        : buildConfigs.dependencies[packageName];
+    final buildConfig = buildConfigs[pubspec.pubPackageName];
 
     final binDir = new Directory(p.join(packageDir, 'bin'));
     final webDir = new Directory(p.join(packageDir, 'web'));

--- a/dazel/lib/src/config/build_config.dart
+++ b/dazel/lib/src/config/build_config.dart
@@ -62,6 +62,8 @@ class BuildConfig {
     }
   }
 
+  final String packageName;
+
   /// All the `builders` defined in a `build.yaml` file.
   final dartBuilderBinaries = <String, DartBuilderBinary>{};
 
@@ -72,15 +74,15 @@ class BuildConfig {
   BuildConfig.useDefault(Pubspec pubspec,
       {bool includeWebSources: false,
       bool enableDdc: true,
-      Iterable<String> excludeSources: const []}) {
-    var name = pubspec.pubPackageName;
+      Iterable<String> excludeSources: const []})
+      : packageName = pubspec.pubPackageName {
     var sources = ["lib/**"];
     if (includeWebSources) sources.add("web/**");
-    dartLibraries[name] = new DartLibrary(
+    dartLibraries[packageName] = new DartLibrary(
         dependencies: pubspec.dependencies,
         enableDdc: enableDdc,
         isDefault: true,
-        name: name,
+        name: packageName,
         package: pubspec.pubPackageName,
         sources: sources,
         excludeSources: excludeSources);
@@ -88,7 +90,8 @@ class BuildConfig {
 
   /// Create a [BuildConfig] by parsing [configYaml].
   BuildConfig.parse(Pubspec pubspec, String configYaml,
-      {bool includeWebSources: false}) {
+      {bool includeWebSources: false})
+      : packageName = pubspec.pubPackageName {
     final config = loadYaml(configYaml);
 
     final Map<String, Map> targetConfigs = config['targets'] ?? {};
@@ -125,7 +128,7 @@ class BuildConfig {
         generateFor: generateFor,
         isDefault: isDefault,
         name: targetName,
-        package: pubspec.pubPackageName,
+        package: packageName,
         sources: sources,
       );
     }

--- a/dazel/lib/src/config/config_set.dart
+++ b/dazel/lib/src/config/config_set.dart
@@ -1,0 +1,35 @@
+import 'dart:async';
+
+import '../bazelify/pubspec.dart';
+import 'build_config.dart';
+
+/// The [BuildConfig]s for a package and it's dependencies.
+class BuildConfigSet {
+  final BuildConfig local;
+  final Map<String, BuildConfig> dependencies;
+
+  static Future<BuildConfigSet> forPackages(
+          String localPackagePath,
+          Map<String, String> dependencyPaths,
+          Map<String, Pubspec> dependencyPubspecs) async =>
+      new BuildConfigSet(await _readLocalBuildConfig(localPackagePath),
+          await _readBuildConfigs(dependencyPaths, dependencyPubspecs));
+
+  BuildConfigSet(this.local, this.dependencies);
+}
+
+Future<Map<String, BuildConfig>> _readBuildConfigs(
+    Map<String, String> packagePaths, Map<String, Pubspec> pubspecs) async {
+  final buildConfigs = <String, BuildConfig>{};
+  for (var package in packagePaths.keys) {
+    buildConfigs[package] = await BuildConfig.fromPackageDir(
+        pubspecs[package], packagePaths[package]);
+  }
+  return buildConfigs;
+}
+
+Future<BuildConfig> _readLocalBuildConfig(String packagePath) async {
+  final pubspec = await Pubspec.fromPackageDir(packagePath);
+  return BuildConfig.fromPackageDir(pubspec, packagePath,
+      includeWebSources: true);
+}

--- a/dazel/lib/src/config/config_set.dart
+++ b/dazel/lib/src/config/config_set.dart
@@ -18,6 +18,7 @@ class BuildConfigSet {
   BuildConfigSet(this.local, this.dependencies);
 }
 
+/// Returns a Map from packageName to the [BuildConfig] for the package.
 Future<Map<String, BuildConfig>> _readBuildConfigs(
     Map<String, String> packagePaths, Map<String, Pubspec> pubspecs) async {
   final buildConfigs = <String, BuildConfig>{};

--- a/dazel/lib/src/config/config_set.dart
+++ b/dazel/lib/src/config/config_set.dart
@@ -16,6 +16,9 @@ class BuildConfigSet {
           await _readBuildConfigs(dependencyPaths, dependencyPubspecs));
 
   BuildConfigSet(this.local, this.dependencies);
+
+  BuildConfig operator [](String packageName) =>
+      packageName == local.packageName ? local : dependencies[packageName];
 }
 
 /// Returns a Map from packageName to the [BuildConfig] for the package.

--- a/dazel/test/build_file_test.dart
+++ b/dazel/test/build_file_test.dart
@@ -5,6 +5,7 @@ import 'package:dazel/src/bazelify/build.dart';
 import 'package:dazel/src/bazelify/common.dart';
 import 'package:dazel/src/bazelify/pubspec.dart';
 import 'package:dazel/src/config/build_config.dart';
+import 'package:dazel/src/config/config_set.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -20,15 +21,12 @@ void main() {
       Iterable<DartWebApplication> webApps: const [],
       Iterable<DartVmBinary> binaries: const []}) {
     final pubspec = new Pubspec.parse(pubspecYaml);
-    final bazelConfig = new BuildConfig.useDefault(pubspec,
+    final buildConfig = new BuildConfig.useDefault(pubspec,
         enableDdc: enableDdc,
         excludeSources: excludeSources,
         includeWebSources: webApps.isNotEmpty);
-    final bazelConfigs = {
-      pubspec.pubPackageName: bazelConfig,
-    }..addAll(extraConfigs);
-    return new BuildFile(bazelConfig, bazelConfigs,
-        webApps: webApps, binaries: binaries);
+    final buildConfigs = new BuildConfigSet(buildConfig, extraConfigs);
+    return new BuildFile(buildConfigs, webApps: webApps, binaries: binaries);
   }
 
   test('should generate a simple library with no dependencies', () {
@@ -108,12 +106,9 @@ void main() {
         bool includeWebSources: false}) async {
       packageDir = p.normalize(packageDir);
       final pubspec = await Pubspec.fromPackageDir(packageDir);
-      final buildConfig = await BuildConfig.fromPackageDir(
-          pubspec, packageDir,
+      final buildConfig = await BuildConfig.fromPackageDir(pubspec, packageDir,
           includeWebSources: includeWebSources);
-      final buildConfigs = {
-        pubspec.pubPackageName: buildConfig,
-      }..addAll(extraConfigs);
+      final buildConfigs = new BuildConfigSet(buildConfig, extraConfigs);
       return BuildFile.fromPackageDir(packageDir, pubspec, buildConfigs);
     }
 

--- a/dazel/test/build_file_test.dart
+++ b/dazel/test/build_file_test.dart
@@ -25,8 +25,11 @@ void main() {
         enableDdc: enableDdc,
         excludeSources: excludeSources,
         includeWebSources: webApps.isNotEmpty);
-    final buildConfigs = new BuildConfigSet(buildConfig, extraConfigs);
-    return new BuildFile(buildConfigs, webApps: webApps, binaries: binaries);
+    var allConfigs = {pubspec.pubPackageName: buildConfig}
+      ..addAll(extraConfigs);
+    final buildConfigs = new BuildConfigSet(buildConfig, allConfigs);
+    return new BuildFile(pubspec.pubPackageName, buildConfigs,
+        webApps: webApps, binaries: binaries);
   }
 
   test('should generate a simple library with no dependencies', () {
@@ -108,7 +111,9 @@ void main() {
       final pubspec = await Pubspec.fromPackageDir(packageDir);
       final buildConfig = await BuildConfig.fromPackageDir(pubspec, packageDir,
           includeWebSources: includeWebSources);
-      final buildConfigs = new BuildConfigSet(buildConfig, extraConfigs);
+      var allConfigs = {pubspec.pubPackageName: buildConfig}
+        ..addAll(extraConfigs);
+      final buildConfigs = new BuildConfigSet(buildConfig, allConfigs);
       return BuildFile.fromPackageDir(packageDir, pubspec, buildConfigs);
     }
 

--- a/dazel/test/build_file_test.dart
+++ b/dazel/test/build_file_test.dart
@@ -25,10 +25,8 @@ void main() {
         enableDdc: enableDdc,
         excludeSources: excludeSources,
         includeWebSources: webApps.isNotEmpty);
-    var allConfigs = {pubspec.pubPackageName: buildConfig}
-      ..addAll(extraConfigs);
-    final buildConfigs = new BuildConfigSet(buildConfig, allConfigs);
-    return new BuildFile(pubspec.pubPackageName, buildConfigs,
+    final buildConfigs = new BuildConfigSet(buildConfig, extraConfigs);
+    return new BuildFile(buildConfig, buildConfigs,
         webApps: webApps, binaries: binaries);
   }
 


### PR DESCRIPTION
Everywhere that we were passing a Map<String, BuildConfig> use instead a
BuildConfigSet. Next refactor will pull out some commonly used methods
around this map into the new class - for instance figuring out whether
any package exposes a Builder.