### PR TITLE
Put codegen.bzl files in their own repository

### DIFF
--- a/dazel/CHANGELOG.md
+++ b/dazel/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.3
+
+* Add support for doing codegen in external packages
+* Upgrade rules_dart 0.4.1
+
 ## 0.3.2
 
 * Add suggestions for .gitignore

--- a/dazel/lib/src/bazelify/build.dart
+++ b/dazel/lib/src/bazelify/build.dart
@@ -170,7 +170,7 @@ class BuildFile {
       var builderPackage = builderDefinition.package;
       buffer
         ..writeln('load(')
-        ..writeln('    "//:.dazel/pub_$builderPackage.codegen.bzl",')
+        ..writeln('    "@dazel_codegen//:pub_$builderPackage.codegen.bzl",')
         ..writeln('    "$builder",')
         ..writeln(')');
     }

--- a/dazel/lib/src/config/config_set.dart
+++ b/dazel/lib/src/config/config_set.dart
@@ -19,7 +19,12 @@ class BuildConfigSet {
 
   BuildConfig operator [](String packageName) =>
       packageName == local.packageName ? local : dependencies[packageName];
+
+  bool get hasCodegen =>
+      _hasCodegen(local) || dependencies.values.any(_hasCodegen);
 }
+
+bool _hasCodegen(BuildConfig config) => config.dartBuilderBinaries.isNotEmpty;
 
 /// Returns a Map from packageName to the [BuildConfig] for the package.
 Future<Map<String, BuildConfig>> _readBuildConfigs(

--- a/dazel/pubspec.yaml
+++ b/dazel/pubspec.yaml
@@ -2,7 +2,7 @@ name: dazel
 description: Bazel support for Dart
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/bazel
-version: 0.3.2
+version: 0.3.3
 
 # NOTE: We require a generated .packages file in order to use this package.
 environment:

--- a/dazel/test/bazel_macro_test.dart
+++ b/dazel/test/bazel_macro_test.dart
@@ -1,6 +1,9 @@
 import 'dart:io';
 
 import 'package:dazel/src/bazelify/macro.dart';
+import 'package:dazel/src/bazelify/pubspec.dart';
+import 'package:dazel/src/config/build_config.dart';
+import 'package:dazel/src/config/config_set.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -29,6 +32,8 @@ void main() {
         [
           'path',
         ],
+        new BuildConfigSet(
+            new BuildConfig.useDefault(new Pubspec.parse('name: foo')), {}),
         (package) => 'some/path/to/.pub_cache/$package-0.0.0');
     expect(
       packagesBzl.toString(),

--- a/dazel/test/goldens/build_file_codegen_consumer
+++ b/dazel/test/goldens/build_file_codegen_consumer
@@ -5,7 +5,7 @@
 load("@io_bazel_rules_dart//dart/build_rules:core.bzl", "dart_library")
 
 load(
-    "//:.dazel/pub_codegen_author.codegen.bzl",
+    "@dazel_codegen//:pub_codegen_author.codegen.bzl",
     "some_builder",
 )
 package(default_visibility = ["//visibility:public"])


### PR DESCRIPTION
Fixes #143

When these files exist in the root repository they can't be read by
external repositories unless we give the root workspace a name - and
then we would need to identify them different in local vs externa BUILD
files. Instead, creat a respository specifically to hold the .bzl files.

- Create a directory .dazel/codegen and a BUILD file
- Put the *.codege.bzl files in this directory
- Create a helper field `hasCodegen` in the BuildConfigSet so we don't
  need to repeat this logic
- When using codegen create a `local_repository` for the codegen rules
  in packages.bzl
- Update to latest rules_dart
- Rename bazelifyPath -> dazelDir