### PR TITLE
Log with package:stack_trace

### DIFF
--- a/bazel_codegen/CHANGELOG.md
+++ b/bazel_codegen/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.0-dev
+
+- Wrap generation in Chain.capture and print full asynchronous stack traces
+
 # 0.0.3
 
 - Only read '.dart' files as sources for the Resolver. This avoids a problem

--- a/bazel_codegen/lib/_bazel_codegen.dart
+++ b/bazel_codegen/lib/_bazel_codegen.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:build/build.dart';
+import 'package:stack_trace/stack_trace.dart';
 
 import 'src/run_phases.dart';
 
@@ -46,11 +47,13 @@ Future bazelGenerate(BuilderFactory builderFactory, List<String> args,
 /// declared outputs.
 Future bazelGenerateMulti(List<BuilderFactory> builders, List<String> args,
     {Map<String, String> defaultContent: const {}}) {
-  if (_isWorker(args)) {
-    return generateAsWorker(builders, defaultContent);
-  } else {
-    return generateSingleBuild(builders, args, defaultContent);
-  }
+  return Chain.capture(() {
+    if (_isWorker(args)) {
+      return generateAsWorker(builders, defaultContent);
+    } else {
+      return generateSingleBuild(builders, args, defaultContent);
+    }
+  });
 }
 
 /// Whether generation is running in worker mode.

--- a/bazel_codegen/lib/_bazel_codegen.dart
+++ b/bazel_codegen/lib/_bazel_codegen.dart
@@ -53,8 +53,10 @@ Future bazelGenerateMulti(List<BuilderFactory> builders, List<String> args,
     } else {
       return generateSingleBuild(builders, args, defaultContent);
     }
-  });
+  }, when: _useChain(args));
 }
 
 /// Whether generation is running in worker mode.
 bool _isWorker(Iterable<String> args) => args.contains('--persistent_worker');
+
+bool _useChain(Iterable<String> args) => args.contains('--async_stack_trace');

--- a/bazel_codegen/lib/src/args/build_args.dart
+++ b/bazel_codegen/lib/src/args/build_args.dart
@@ -56,7 +56,7 @@ Map<String, Level> _optionToLogLevel = {
 };
 
 /// Parsed arguments for code generator binaries.
-class Options {
+class BuildArgs {
   final List<String> rootDirs;
   final String packagePath;
   final String outDir;
@@ -71,7 +71,7 @@ class Options {
   final bool useSummaries;
   final List<String> additionalArgs;
 
-  Options._(
+  BuildArgs._(
       this.rootDirs,
       this.packagePath,
       this.outDir,
@@ -86,7 +86,7 @@ class Options {
       this.useSummaries: true,
       this.additionalArgs});
 
-  factory Options.parse(List<String> args, {bool isWorker}) {
+  factory BuildArgs.parse(List<String> args, {bool isWorker}) {
     // When not running as a worker, but that mode is supported, then we get
     // just this arg which points at a file containing the arguments.
     if (args.length == 1 && args.first.startsWith('@')) {
@@ -110,8 +110,17 @@ class Options {
     final help = argResults[_helpParam];
     final useSummaries = argResults[_summariesParam];
 
-    return new Options._(rootDirs, packagePath, outDir, logPath, inputExtension,
-        outputExtensions, packageMapPath, srcsPath, help, logLevel,
+    return new BuildArgs._(
+        rootDirs,
+        packagePath,
+        outDir,
+        logPath,
+        inputExtension,
+        outputExtensions,
+        packageMapPath,
+        srcsPath,
+        help,
+        logLevel,
         additionalArgs: argResults.rest,
         isWorker: isWorker,
         useSummaries: useSummaries);

--- a/bazel_codegen/lib/src/args/startup_args.dart
+++ b/bazel_codegen/lib/src/args/startup_args.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2017, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'package:args/args.dart';
+
+const _persistentWorkerParam = 'persistent_worker';
+const _asyncStackTraceParam = 'async-stack-trace';
+
+final _argParser = new ArgParser(allowTrailingOptions: true)
+  ..addFlag(_persistentWorkerParam,
+      negatable: false,
+      defaultsTo: false,
+      help: 'Whether to run in worker mode')
+  ..addFlag(_asyncStackTraceParam,
+      negatable: true,
+      defaultsTo: false,
+      help: 'Whether to capture a chain of async stack traces');
+
+class StartupArgs {
+  final bool persistentWorker;
+  final bool asyncStackTrace;
+  final List<String> buildArgs;
+
+  StartupArgs._(this.persistentWorker, this.asyncStackTrace, this.buildArgs);
+
+  factory StartupArgs.parse(List<String> args) {
+    final argResults = _argParser.parse(args);
+    final persistentWorker = argResults[_persistentWorkerParam];
+    final asyncStackTrace = argResults[_asyncStackTraceParam];
+
+    return new StartupArgs._(
+        persistentWorker, asyncStackTrace, argResults.rest);
+  }
+}

--- a/bazel_codegen/lib/src/logging.dart
+++ b/bazel_codegen/lib/src/logging.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:logging/logging.dart';
+import 'package:stack_trace/stack_trace.dart';
 
 /// A handle on a [Logger] which writes logs to an [IOSink] incrementally.
 ///
@@ -79,7 +80,9 @@ Logger _createLogger() {
 String _logMessage(LogRecord record) {
   var buffer = new StringBuffer('[${record.level}]: ${record.message}');
   if (record.error != null) buffer.write('\n${record.error}');
-  if (record.stackTrace != null) buffer.write('\n${record.stackTrace}');
+  if (record.stackTrace != null) {
+    buffer.write('\n${new Chain.forTrace(record.stackTrace).terse}');
+  }
   return buffer.toString();
 }
 

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -2,7 +2,7 @@ name: _bazel_codegen
 description: Bazel code generation runner
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/bazel
-version: 0.0.3
+version: 0.1.0-dev
 
 environment:
   sdk: ">=1.8.0 <2.0.0"
@@ -15,6 +15,7 @@ dependencies:
   build_barback: ^0.1.0
   logging: ^0.11.3
   path: ^1.4.1
+  stack_trace: ^1.7.0
 
 dev_dependencies:
   test: ^0.12.15+2


### PR DESCRIPTION
Typical stack traces are typically useless since all work in a Builder
happens asynchronously.

- Wrap the entire generation in Chain.capture. bazelGenerate is
  intentionally excluded since it will be removed
- When logging messages that include a StackTrace, convert it to a Chain
  to log more detail