### PR TITLE
Drop unused apis

### DIFF
--- a/bazel_codegen/CHANGELOG.md
+++ b/bazel_codegen/CHANGELOG.md
@@ -1,6 +1,8 @@
-# 0.1.0-dev
+# 0.1.0
 
 - Wrap generation in Chain.capture and print full asynchronous stack traces
+- **BREAKING** `bazelGenerate` and `noArgs` have been dropped. These are unused
+  from the template file in `rules_dart` which is the supported approach.
 
 # 0.0.3
 

--- a/bazel_codegen/lib/_bazel_codegen.dart
+++ b/bazel_codegen/lib/_bazel_codegen.dart
@@ -11,23 +11,6 @@ import 'src/run_phases.dart';
 
 typedef Builder BuilderFactory(List<String> args);
 
-/// Wrap [builder] as a [BuilderFactory] that expects no arguments.
-///
-/// If any unexpected arguments are passed throws a StateError.
-BuilderFactory noArgs(Builder builder) => (List<String> args) {
-      if (args?.isNotEmpty == true) {
-        throw new StateError('No arguments should be passed to this builder.');
-      }
-      return builder;
-    };
-
-/// Runs a single Builder to generate files.
-///
-/// See [bazelGenerateMulti] for more details.
-Future bazelGenerate(BuilderFactory builderFactory, List<String> args,
-        {Map<String, String> defaultContent: const {}}) =>
-    bazelGenerateMulti([builderFactory], args, defaultContent: defaultContent);
-
 /// Runs [builders] to generate files.
 ///
 /// This should be typically invoked with [args] from a dart_codegen build

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -2,7 +2,7 @@ name: _bazel_codegen
 description: Bazel code generation runner
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/bazel
-version: 0.1.0-dev
+version: 0.1.0
 
 environment:
   sdk: ">=1.8.0 <2.0.0"


### PR DESCRIPTION
These apis were useful when authors were manually writing codegen
binaries. Now that the scripts are generated there is no need to keep
these apis around.