### PR TITLE
Update documentation for build.yaml

### DIFF
--- a/dazel/README.md
+++ b/dazel/README.md
@@ -1,6 +1,6 @@
 `dazel` is a tool to generate an manage bazel workspaces for Dart projects.
 
-### Installation
+# Installation
 
 [install-bazel]: https://www.bazel.io/versions/master/docs/install.html
 
@@ -12,7 +12,9 @@ adding a `dev_dependency` on the `dazel` package.
 
 [pub_run]: https://www.dartlang.org/tools/pub/cmd/pub-run
 
-### Generation
+# Usage
+
+## Setup
 
 You can run `dazel` on a typical `pub` package:
 
@@ -32,7 +34,7 @@ $ pub run dazel init
 If you don't have a project, you can use our `workspace` folder of examples. See
 `tool/presubmit.dart` for some examples.
 
-### Usage
+## Running
 
 You can `bazel run` files in `bin/`:
 
@@ -55,7 +57,7 @@ Oh, and did we mention support for the [Dart dev compiler][ddc]?
 
 The dazel server supports both dart code on Dartium and js compiled with DDC.
 
-### Cleaning up
+## Cleaning up
 
 We automatically generate a bunch of file for you - these should not be checked
 in to your repository - you can safely ignore them when commiting. Here is an
@@ -79,18 +81,19 @@ analyzer:
     - 'bazel-*/**'
 ```
 
-### Customizing your generated BUILD files
+# Customizing builds
 
-Customizing the BUILD file output of a package is done  by creating a
-`build.yaml` file, which describes your configuration.
+Customizing the build behavior of a package is done  by creating a `build.yaml`
+file, which describes your configuration.
 
-#### Splitting your package into multiple targets
+## Splitting your package into multiple targets
 
 It is fairly common for a package to want to split up their sources into
-multiple bazel targets. Specifically, this is useful if your package has some
-sources which are web friendly, and others which are not.
+multiple targets which each implement a particular feature. Specifically, this
+is useful if your package has some sources which are web friendly, and others
+which are not.
 
-This is done by adding a `targets` section to your `build.yaml` file, which
+To split up a package add a `targets` section to your `build.yaml` file, which
 defines the different targets that you wish to be generated. This is a map of
 target names to configuration. Each target config may contain the following
 keys:
@@ -112,15 +115,9 @@ keys:
 - **builders**: Optional, defaults to empty. The builders to apply to this
   target. These are defined by this package or other packages in the `builders`
   section of their build.yaml.
-  - **NOTE**: This is not implemented and will throw an `UnimplementedError`.
-  - A `List<String|Map>`, for Map values the key is the name of the builder, and
-    the value will be parsed and passed into the builder constructor as a part
-    of the `BuilderSettings` object.
-  - There is one magic config option, `$generate_for`, which overrides the
-    target's `generate_for` option just for this builder.
+  - A `List<String>` with the names of the builders run on the library.
 - **generate_for**: Optional, defaults to `sources`. The files to treat as
   inputs to all `builders`. Supports glob syntax.
-  - **NOTE**: This is not implemented and will throw an `UnimplementedError`.
 
 
 Example `targets` section for a package with two targets and some builders
@@ -134,14 +131,13 @@ targets:
       - "lib/a.dart"
       - "lib/src/**"
     exclude_sources:
+      - "lib/transformer.dart"
       - "lib/src/transformer/**"
     dependencies:
       - "some_package"
       - "some_package:web"
     builders:
-      - "some_package:builder":
-          my_option: some_value
-          $generate_for:
+      - "some_builder_name"
     generate_for:
       - "lib/a.dart"
   transformer:
@@ -154,16 +150,12 @@ targets:
       - "barback"
 ```
 
-#### Defining `Builder`s in your package (similar to transformers)
-
-**NOTE**: Using this config is not yet implemented, adding this to your
-`build.yaml` will cause an `UnimplementedError` to be thrown by dazel today.
+## Defining `Builder`s in your package (similar to transformers)
 
 If users of your package need to apply some code generation to their package,
 then you can define `Builder`s (from [package:build]
-(https://pub.dartlang.org/packages/build)) and have those be either be
-automatically applied based on existing transformer settings, or simply
-available for users to opt into as needed.
+(https://pub.dartlang.org/packages/build)) and have those applied based on the
+consuming package `build.yaml`.
 
 You tell dazel about your `Builder`s using the `builders` section of your
 `build.yaml`. This is a map of builder names to configuration. Each builder
@@ -173,31 +165,16 @@ config may contain the following keys:
   definition.
 - **import**: Required. The import uri that should be used to import the library
   containing the `Builder` class. This should always be a `package:` uri.
-- **class**: The name of the `Builder` class to instantiate, must be exported by
-  the library referenced by `import`.
-- **constructor**: Optional. The name of the constructor to use for `class` if
-  not the default one.
-  - This must follow a specific format, probably taking a single
-    `BuilderSettings` positional parameter.
-- **replaces_transformer**: Optional. The name of a transformer (as it would
-  appear in a pubspec) that this should be used in place of. Any package with
-  that transformer and a dependency on this package should get this builder
-  applied.
-  - If a user has a custom `build.yaml` file then this has no effect, they
-    must explicitly list all builders.
-- **input_extension**: Required. The input extensions to treat as primary inputs
-  to the builder.
+- **builder_factories**: A `List<String>` which contains the names of the
+  top-level methods in the imported library which are a function fitting the
+  typedef `Builder factoryName(List<String> args)`. When multiple builders are
+  used the create a pipeline - the outputs of the first builder become the
+  inputs into the next builder.
+- **input_extension**: Required. The input extension to treat as primary inputs
+  to the builder.:w
 - **output_extensions**: Required. The output extensions of this builder.
   - For each file matching `input_extension`, a matching file with each of
     `output_extensions` must be output.
-- **shared_part_output**: Optional, defaults to `false`. If `true` then the
-  output of this rule is actually treated as only a piece of a larger dart file,
-  which is a part (dart part) of a different library.
-  - It may not contain any directives that have ordering concerns such as
-    `library`, `import`, `export`, or `part`.
-  - All of the buiders that output to the same file will be output to a temp
-    file and then be concatenated together into the actual part file (and the
-    part of statement will be prepended to it).
 
 Example `builders` config:
 
@@ -209,17 +186,15 @@ targets:
       - "lib/src/builder/**/*.dart"
       - "lib/builder.dart"
     dependencies:
+      - "build"
       - "source_gen"
 builders:
   # The actual builder config.
   my_builder:
     target: ":_my_builder"
-    import: "package:my_package/builders/my_builder.dart"
-    class: "MyBuilder"
-    constructor: "withBuildConfig"
-    replaces_transformer: "my_package"
+    import: "package:my_package/builder.dart"
+    builder_factories: ["myBuilder"]
     input_extension: ".dart"
     output_extensions:
-      - ".g.dart"
-    shared_part_output: true
+      - ".my_package.dart"
 ```


### PR DESCRIPTION
- Graduate headers to higher levels
- Organize into more heirarchical sections
- Remove some references to `BUILD` files and stick with terms related
  to higher level concepts.
- Drop documentation on removed or unsupported configuration around
  builders