### PR TITLE
Drop stale unsupported concept replacesTransfomer

### DIFF
--- a/dazel/lib/src/bazelify/build.dart
+++ b/dazel/lib/src/bazelify/build.dart
@@ -570,12 +570,6 @@ class DartBuilderBinary implements DartBuildRule {
   /// these extensions must be output.
   final Iterable<String> outputExtensions;
 
-  /// The name of a transformer (as it appears in a pubspec.yaml) that this
-  /// builder replaces.
-  ///
-  /// May be null.
-  final String replacesTransformer;
-
   /// The name of the dart_library target that contains `import`.
   final String target;
 
@@ -586,7 +580,6 @@ class DartBuilderBinary implements DartBuildRule {
       this.name,
       this.outputExtensions,
       this.package,
-      this.replacesTransformer,
       this.target});
 
   @override
@@ -605,7 +598,6 @@ class DartBuilderBinary implements DartBuildRule {
       'name: $name\n'
       'outputExtensions: $outputExtensions\n'
       'package: $package\n'
-      'replacesTransformer: $replacesTransformer\n'
       'target: $target';
 
   String toCodegenRule() {

--- a/dazel/lib/src/config/build_config.dart
+++ b/dazel/lib/src/config/build_config.dart
@@ -36,14 +36,12 @@ class BuildConfig {
     _import,
     _inputExtension,
     _outputExtensions,
-    _replacesTransformer,
     _target,
   ];
   static const _builderFactories = 'builder_factories';
   static const _import = 'import';
   static const _inputExtension = 'input_extension';
   static const _outputExtensions = 'output_extensions';
-  static const _replacesTransformer = 'replaces_transformer';
   static const _target = 'target';
 
   /// Returns a parsed [BuildConfig] file in [path], if one exists.
@@ -162,9 +160,6 @@ class BuildConfig {
       final inputExtension = _readStringOrThrow(builderConfig, _inputExtension);
       final outputExtensions =
           _readListOfStringsOrThrow(builderConfig, _outputExtensions);
-      final replacesTransformer = _readStringOrThrow(
-          builderConfig, _replacesTransformer,
-          allowNull: true);
       final target = _readStringOrThrow(builderConfig, _target);
 
       dartBuilderBinaries[builderName] = new DartBuilderBinary(
@@ -174,7 +169,6 @@ class BuildConfig {
         name: builderName,
         outputExtensions: outputExtensions,
         package: pubspec.pubPackageName,
-        replacesTransformer: replacesTransformer,
         target: target,
       );
     }

--- a/dazel/test/bazelify_config_test.dart
+++ b/dazel/test/bazelify_config_test.dart
@@ -43,7 +43,6 @@ void main() {
           '.json',
         ],
         package: 'example',
-        replacesTransformer: 'example',
         target: 'e',
       ),
     });
@@ -72,7 +71,6 @@ void main() {
           '.json',
         ],
         package: 'example',
-        replacesTransformer: 'example',
         target: 'example',
       ),
     });
@@ -114,7 +112,6 @@ builders:
     output_extensions:
       - .g.dart
       - .json
-    replaces_transformer: example
     target: e
 ''';
 
@@ -127,7 +124,6 @@ builders:
     output_extensions:
       - .g.dart
       - .json
-    replaces_transformer: example
     target: example
 ''';
 
@@ -160,7 +156,6 @@ class _DartBuilderBinaryMatcher extends Matcher {
       item.name == _expected.name &&
       equals(item.outputExtensions).matches(_expected.outputExtensions, _) &&
       item.package == _expected.package &&
-      item.replacesTransformer == _expected.replacesTransformer &&
       item.target == _expected.target;
 
   @override


### PR DESCRIPTION
We don't currently support automatically reading pubspec.yaml
transformer config and dropping in a Builder in it's place. Adding this
support is likely more effort than the value we'd get out of it - so for
now drop the concept entirely.

Documentation for this is cleaned up in a separate commit.