### PR TITLE
Explicit error when srcs are duplicated in deps

### DIFF
--- a/bazel_codegen/CHANGELOG.md
+++ b/bazel_codegen/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.1
+
+- Throw an exception when attempting to do resolution on an input file that is
+  also included in a dependency when using summaries.
+
 # 0.1.0
 
 - Wrap generation in Chain.capture and print full asynchronous stack traces

--- a/bazel_codegen/lib/src/summaries/resolvers.dart
+++ b/bazel_codegen/lib/src/summaries/resolvers.dart
@@ -83,6 +83,9 @@ class AnalysisResolver implements ReleasableResolver {
     var uri = assetUri(assetId);
     var source = _analysisContext.sourceFactory.forUri2(uri);
     if (source == null) throw 'missing source for $uri';
+    if (_assetIds.contains(assetId) && source is! AssetSource) {
+      throw '$uri is an input and should not be a src in a dependency';
+    }
     var kind = _analysisContext.computeKindOf(source);
     if (kind != SourceKind.LIBRARY) return null;
     var library = _analysisContext.computeLibraryElement(source);

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -2,7 +2,7 @@ name: _bazel_codegen
 description: Bazel code generation runner
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/bazel
-version: 0.1.0
+version: 0.1.1
 
 environment:
   sdk: ">=1.8.0 <2.0.0"


### PR DESCRIPTION
Most builders expect to be able to do deeper resolution on their inputs
than what is possible with summaries. When a URI is resolvable through
both the file and a summary the summary ends up getting preferred.
Detect when this situation happens and throw a more explicit message
rather than defer until some resolution is attempted that doesn't work.
This will make the resolver behave more consistently and not silently
fallback to a less powerful mode in some cases.

It's possible that this will cause failures in places that otherwise
would have worked if the Builder wouldn't have needed the deeper
resolution.

One place where this comes up is `source_gen` where we require that
inputs with parts use non-summary resolution.