### PR TITLE
Use inputs before summaries in analysis context

### DIFF
--- a/bazel_codegen/CHANGELOG.md
+++ b/bazel_codegen/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.2
+
+- Give priority to reading inputs directly rather than resolving through a
+  summary if they are duplicated.
+
 # 0.1.1
 
 - Throw an exception when attempting to do resolution on an input file that is

--- a/bazel_codegen/lib/src/summaries/analysis_context.dart
+++ b/bazel_codegen/lib/src/summaries/analysis_context.dart
@@ -29,7 +29,10 @@ AnalysisContext summaryAnalysisContext(
   var summaryResolver =
       new InSummaryUriResolver(PhysicalResourceProvider.INSTANCE, summaryData);
 
-  var resolvers = [sdkResolver, summaryResolver]..addAll(additionalResolvers);
+  var resolvers = []
+    ..addAll(additionalResolvers)
+    ..add(sdkResolver)
+    ..add(summaryResolver);
   var sourceFactory = new SourceFactory(resolvers);
 
   var context = AnalysisEngine.instance.createAnalysisContext();

--- a/bazel_codegen/lib/src/summaries/resolvers.dart
+++ b/bazel_codegen/lib/src/summaries/resolvers.dart
@@ -83,9 +83,6 @@ class AnalysisResolver implements ReleasableResolver {
     var uri = assetUri(assetId);
     var source = _analysisContext.sourceFactory.forUri2(uri);
     if (source == null) throw 'missing source for $uri';
-    if (_assetIds.contains(assetId) && source is! AssetSource) {
-      throw '$uri is an input and should not be a src in a dependency';
-    }
     var kind = _analysisContext.computeKindOf(source);
     if (kind != SourceKind.LIBRARY) return null;
     var library = _analysisContext.computeLibraryElement(source);

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -2,7 +2,7 @@ name: _bazel_codegen
 description: Bazel code generation runner
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/bazel
-version: 0.1.1
+version: 0.1.2
 
 environment:
   sdk: ">=1.8.0 <2.0.0"


### PR DESCRIPTION
In some cases a source file can show up in multiple targets. When a
source is also used in a dependency then resolving the file will use the
version from a summary, which is missing some information that is needed
for codegen. Reordering the URI resolvers give precedence to the
resolver that reads from the input.

This will make performance more sensitive to bugs in the skylark rules
that may cause more Dart files to show up as inputs rather than only in
summaries.