### PR TITLE
Drop the packagePath field from BazelAssetReader

### DIFF
--- a/bazel_codegen/lib/src/assets/asset_reader.dart
+++ b/bazel_codegen/lib/src/assets/asset_reader.dart
@@ -10,12 +10,8 @@ import 'package:path/path.dart' as p;
 import '../errors.dart';
 import 'asset_filter.dart';
 import 'file_system.dart';
-import 'path_translation.dart' as path_translation;
 
 class BazelAssetReader implements AssetReader {
-  /// The path to the package we are currently processing.
-  final String packagePath;
-
   /// The bazel specific file system.
   ///
   /// Responsible for knowing where bazel stores source and generated files on
@@ -30,28 +26,13 @@ class BazelAssetReader implements AssetReader {
 
   int numAssetsReadFromDisk = 0;
 
-  BazelAssetReader._(
-      this.packagePath, Iterable<String> rootDirs, this._packageMap,
+  BazelAssetReader(Iterable<String> rootDirs, this._packageMap,
       {AssetFilter assetFilter})
       : _fileSystem = new BazelFileSystem('.', rootDirs),
         _assetFilter = assetFilter;
 
-  factory BazelAssetReader(String packagePath, Iterable<String> rootDirs,
-      Map<String, String> packageMap,
-      {AssetFilter assetFilter}) {
-    if (packagePath.endsWith('/')) {
-      packagePath = packagePath.substring(0, packagePath.length - 1);
-    }
-    return new BazelAssetReader._(packagePath, rootDirs, packageMap,
-        assetFilter: assetFilter);
-  }
-
-  BazelAssetReader.forTest(this.packagePath, this._packageMap, this._fileSystem)
+  BazelAssetReader.forTest(this._packageMap, this._fileSystem)
       : _assetFilter = const _AllowAllAssets();
-
-  /// Peform package name resolution and turn file paths into [AssetId]s.
-  Iterable<AssetId> findAssetIds(Iterable<String> assetPaths) =>
-      path_translation.findAssetIds(assetPaths, packagePath, _packageMap);
 
   @override
   Future<List<int>> readAsBytes(AssetId id) async {

--- a/bazel_codegen/lib/src/run_phases.dart
+++ b/bazel_codegen/lib/src/run_phases.dart
@@ -15,6 +15,7 @@ import 'args/build_args.dart';
 import 'assets/asset_filter.dart';
 import 'assets/asset_reader.dart';
 import 'assets/asset_writer.dart';
+import 'assets/path_translation.dart';
 import 'errors.dart';
 import 'logging.dart';
 import 'summaries/summaries.dart';
@@ -130,11 +131,9 @@ Future<IOSinkLogHandle> _runBuilders(
 
   final writer = new BazelAssetWriter(buildArgs.outDir, packageMap,
       validInputs: validInputs);
-  final reader = new BazelAssetReader(
-      buildArgs.packagePath, buildArgs.rootDirs, packageMap,
+  final reader = new BazelAssetReader(buildArgs.rootDirs, packageMap,
       assetFilter: new AssetFilter(validInputs, packageMap, writer));
-  final srcAssets = reader
-      .findAssetIds(srcPaths)
+  final srcAssets = findAssetIds(srcPaths, buildArgs.packagePath, packageMap)
       .where((id) => id.path.endsWith(buildArgs.inputExtension))
       .toList();
   var logHandle = new IOSinkLogHandle.toFile(buildArgs.logPath,

--- a/bazel_codegen/test/asset_reader_test.dart
+++ b/bazel_codegen/test/asset_reader_test.dart
@@ -14,21 +14,12 @@ void main() {
   const packageName = 'test.package.test_package';
   const packageMap = const {packageName: packagePath};
   final f1AssetId = new AssetId(packageName, 'lib/filename1.dart');
-  final f2AssetId = new AssetId(packageName, 'lib/src/filename2.dart');
   BazelAssetReader reader;
   FakeFileSystem fileSystem;
 
   setUp(() {
     fileSystem = new FakeFileSystem();
-    reader = new BazelAssetReader.forTest(packagePath, packageMap, fileSystem);
-  });
-
-  test('findAssetids tranlsates paths', () {
-    final translatedAssets = reader.findAssetIds([
-      'test/package/test_package/lib/filename1.dart',
-      'test/package/test_package/lib/src/filename2.dart',
-    ]);
-    expect(translatedAssets, equals([f1AssetId, f2AssetId]));
+    reader = new BazelAssetReader.forTest(packageMap, fileSystem);
   });
 
   test('hasInput', () async {

--- a/bazel_codegen/test/path_translation_test.dart
+++ b/bazel_codegen/test/path_translation_test.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2017, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'package:build/build.dart';
+import 'package:test/test.dart';
+
+import 'package:_bazel_codegen/src/assets/path_translation.dart';
+
+void main() {
+  const packagePath = 'test/package/test_package';
+  const packageName = 'test.package.test_package';
+  const packageMap = const {packageName: packagePath};
+  final f1AssetId = new AssetId(packageName, 'lib/filename1.dart');
+  final f2AssetId = new AssetId(packageName, 'lib/src/filename2.dart');
+
+  test('findAssetids translates paths', () {
+    final translatedAssets = findAssetIds([
+      'test/package/test_package/lib/filename1.dart',
+      'test/package/test_package/lib/src/filename2.dart',
+    ], packagePath, packageMap);
+    expect(translatedAssets, equals([f1AssetId, f2AssetId]));
+  });
+}


### PR DESCRIPTION
This field is used for very little and will be superfluous when we add
a packageName field in order to support findAssets.

- Drop the findAssetIds wrapper around the top-level method from the
  asset reader
- Call the top-level method from the single usage site
- Drop the packagePath field
- Collaps the factory constructor into the private constructor since we
  no longer need any munging of the packagePath argment
- Move tests