### PR TITLE
Implement findAssets api

### DIFF
--- a/bazel_codegen/CHANGELOG.md
+++ b/bazel_codegen/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.3
+
+- Upgrade to build 0.8.0, implement findAssets api
+
 # 0.1.2
 
 - Give priority to reading inputs directly rather than resolving through a

--- a/bazel_codegen/lib/src/assets/file_system.dart
+++ b/bazel_codegen/lib/src/assets/file_system.dart
@@ -5,6 +5,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
+import 'package:glob/glob.dart';
 
 class BazelFileSystem {
   final String workspaceDir;
@@ -31,6 +32,17 @@ class BazelFileSystem {
   //TODO(nbosch) replace with async version
   String readAsStringSync(String path, {Encoding encoding: UTF8}) =>
       _fileForPath(path).readAsStringSync(encoding: encoding ?? UTF8);
+
+  Iterable<String> findAssets(String packagePath, Glob glob) sync* {
+    for (var searchPath in searchPaths) {
+      var fullPath = p.join(workspaceDir, searchPath, packagePath);
+      if (!new Directory(fullPath).existsSync()) continue;
+      yield* glob
+          .listSync(root: fullPath)
+          .map((e) => e.path)
+          .map((path) => p.relative(path, from: fullPath));
+    }
+  }
 
   File _fileForPath(String path) {
     for (var searchPath in searchPaths) {

--- a/bazel_codegen/lib/src/run_phases.dart
+++ b/bazel_codegen/lib/src/run_phases.dart
@@ -129,9 +129,13 @@ Future<IOSinkLogHandle> _runBuilders(
         value: (l) => l[1]);
   });
 
+  final packageName = packageMap.keys
+      .firstWhere((name) => packageMap[name] == buildArgs.packagePath);
+
   final writer = new BazelAssetWriter(buildArgs.outDir, packageMap,
       validInputs: validInputs);
-  final reader = new BazelAssetReader(buildArgs.rootDirs, packageMap,
+  final reader = new BazelAssetReader(
+      packageName, buildArgs.rootDirs, packageMap,
       assetFilter: new AssetFilter(validInputs, packageMap, writer));
   final srcAssets = findAssetIds(srcPaths, buildArgs.packagePath, packageMap)
       .where((id) => id.path.endsWith(buildArgs.inputExtension))

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -19,3 +19,8 @@ dependencies:
 
 dev_dependencies:
   test: ^0.12.15+2
+  test_descriptor: ^1.0.0
+
+dependency_overrides:
+  build:
+    path: ../../pkg-build/build

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -2,7 +2,7 @@ name: _bazel_codegen
 description: Bazel code generation runner
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/bazel
-version: 0.1.2
+version: 0.1.3
 
 environment:
   sdk: ">=1.8.0 <2.0.0"
@@ -11,7 +11,7 @@ dependencies:
   analyzer: ^0.29.5
   args: ^0.13.6
   bazel_worker: ^0.1.2
-  build: ^0.7.2
+  build: ^0.8.0
   build_barback: ^0.1.0
   logging: ^0.11.3
   path: ^1.4.1

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -20,7 +20,3 @@ dependencies:
 dev_dependencies:
   test: ^0.12.15+2
   test_descriptor: ^1.0.0
-
-dependency_overrides:
-  build:
-    path: ../../pkg-build/build

--- a/bazel_codegen/test/asset_reader_test.dart
+++ b/bazel_codegen/test/asset_reader_test.dart
@@ -15,6 +15,7 @@ void main() {
   const packageName = 'test.package.test_package';
   const packageMap = const {packageName: packagePath};
   final f1AssetId = new AssetId(packageName, 'lib/filename1.dart');
+  final f2AssetId = new AssetId(packageName, 'lib/filename2.dart');
   BazelAssetReader reader;
   FakeFileSystem fileSystem;
 
@@ -52,9 +53,8 @@ void main() {
   });
 
   test('findAssets', () async {
-    fileSystem.nextFindAssets = ['lib/foo.dart'];
-    expect(reader.findAssets(new Glob('lib/*.dart')),
-        [new AssetId(packageName, 'lib/foo.dart')]);
+    fileSystem.nextFindAssets = ['lib/filename1.dart', 'lib/filename2.dart'];
+    expect(reader.findAssets(new Glob('lib/*.dart')), [f1AssetId, f2AssetId]);
   });
 }
 

--- a/bazel_codegen/test/file_system_test.dart
+++ b/bazel_codegen/test/file_system_test.dart
@@ -1,0 +1,27 @@
+import 'package:glob/glob.dart';
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+import 'package:_bazel_codegen/src/assets/file_system.dart';
+
+void main() {
+  BazelFileSystem fileSystem;
+
+  setUp(() async {
+    fileSystem = new BazelFileSystem(d.sandbox, ['', 'blaze-bin']);
+  });
+
+  test('findAssets lists files across search paths', () async {
+    await d.dir('some_package', [
+      d.dir('lib', [d.file('foo.dart')])
+    ]).create();
+    await d.dir('blaze-bin', [
+      d.dir('some_package', [
+        d.dir('lib', [d.file('bar.dart')])
+      ])
+    ]).create();
+
+    expect(fileSystem.findAssets('some_package', new Glob('lib/*.dart')),
+        ['lib/foo.dart', 'lib/bar.dart']);
+  });
+}


### PR DESCRIPTION
- Implement findAssets based on package path in BazelFileSystem
- Add a rootPackageName field to BazelAssetReader - it is necessary to
  reconstruct an AssetId for paths within the root package
- Implement findAssets in BazelAssetReader
- Add a simple test for findAssets
- Bump to build 0.8.0