### PR TITLE
Add toString() on AssetSource

### DIFF
--- a/bazel_codegen/CHANGELOG.md
+++ b/bazel_codegen/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.4-dev
+
+- Add a `toString()` on AssetSource.
+
 # 0.1.3
 
 - Upgrade to build 0.8.0, implement findAssets api

--- a/bazel_codegen/lib/src/summaries/build_asset_uri_resolver.dart
+++ b/bazel_codegen/lib/src/summaries/build_asset_uri_resolver.dart
@@ -85,6 +85,9 @@ class AssetSource implements Source {
 
   @override
   bool exists() => true;
+
+  @override
+  String toString() => 'AssetSource[$_assetId]';
 }
 
 Uri assetUri(AssetId assetId) => assetId.path.startsWith('lib/')

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -2,7 +2,7 @@ name: _bazel_codegen
 description: Bazel code generation runner
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/bazel
-version: 0.1.3
+version: 0.1.4-dev
 
 environment:
   sdk: ">=1.8.0 <2.0.0"


### PR DESCRIPTION
These show up in errors thrown by the analyzer, add a toString that give
a better indication which file is involved.