### PR TITLE
Use accumlated inputs/outputs

### DIFF
--- a/bazel_codegen/CHANGELOG.md
+++ b/bazel_codegen/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.6
+
+- Allow 'side' outputs from a builder. When multiple builders are chained the
+  inputs to builders are no longer limited to only the outputs from the previous
+  builder.
+
 # 0.1.5
 
 - Support for build 0.9.0

--- a/bazel_codegen/lib/src/run_phases.dart
+++ b/bazel_codegen/lib/src/run_phases.dart
@@ -174,9 +174,7 @@ Future<IOSinkLogHandle> _runBuilders(
     }
 
     // Set outputs as inputs into the next builder
-    inputSrcs
-      ..clear()
-      ..addAll(writer.assetsWritten);
+    inputSrcs.addAll(writer.assetsWritten);
     validInputs?.addAll(writer.assetsWritten
         .map((id) => p.join(packageMap[id.package], id.path)));
 

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -2,7 +2,7 @@ name: _bazel_codegen
 description: Bazel code generation runner
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/bazel
-version: 0.1.5
+version: 0.1.6
 
 environment:
   sdk: ">=1.8.0 <2.0.0"
@@ -11,7 +11,7 @@ dependencies:
   analyzer: ^0.29.5
   args: ^0.13.6
   bazel_worker: ^0.1.2
-  build: ^0.9.0
+  build: ^0.9.1
   build_barback: ^0.2.0
   glob: ^1.1.0
   logging: ^0.11.3


### PR DESCRIPTION
Previously any configuration with multiple builders in series needed to
behave as a perfect chain - the outputs from one phase needed to be
exactly the primary inputs to the next phase.

In build 0.9.1 the inputs are filtered to only those which will produce
an output, so we can continue to collect inputs and only the assets
which should be primary inputs will end up being used.