### PR TITLE
Drop unnecessary creation of identical AssetIds

### DIFF
--- a/bazel_codegen/lib/src/summaries/resolvers.dart
+++ b/bazel_codegen/lib/src/summaries/resolvers.dart
@@ -8,8 +8,7 @@ import 'dart:io';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/src/generated/engine.dart' show AnalysisContext;
 import 'package:analyzer/src/generated/source.dart' show SourceKind;
-import 'package:build/build.dart'
-    show Resolvers, Resolver, ReleasableResolver, BuildStep, AssetId;
+import 'package:build/build.dart';
 
 import '../assets/path_translation.dart';
 import 'analysis_context.dart';
@@ -53,9 +52,7 @@ class SummaryResolvers implements Resolvers {
 
   Future<Null> _primeWithSources(ReadAsset readAsset) async {
     var sourceFiles = await new File(_sourcesFile).readAsLines();
-    var assets = findAssetIds(sourceFiles, _packagePath, _packageMap)
-        .map((asset) => new AssetId(asset.package, asset.path))
-        .toList();
+    var assets = findAssetIds(sourceFiles, _packagePath, _packageMap);
     await _assetResolver.addAssets(assets, readAsset);
   }
 }


### PR DESCRIPTION
Some refactoring must have left this pattern. findAssetIds already
returns an Iterable<AssetId> and we don't need to clone the values or
use toList().

Also remove `show` from package:build import since there is nothing
ambiguous.