### PR TITLE
Remove public setter for numAssetsReadFromDisk

### DIFF
--- a/bazel_codegen/lib/src/assets/asset_reader.dart
+++ b/bazel_codegen/lib/src/assets/asset_reader.dart
@@ -27,7 +27,9 @@ class BazelAssetReader implements AssetReader {
   /// Maps package names to path in the bazel file system.
   final Map<String, String> _packageMap;
 
-  int numAssetsReadFromDisk = 0;
+  /// The number of times the [_fileSystem] is hit to read a file.
+  int get fileReadCount => _fileReadCount;
+  int _fileReadCount = 0;
 
   BazelAssetReader(
       this.rootPackageName, Iterable<String> rootDirs, this._packageMap,
@@ -42,14 +44,14 @@ class BazelAssetReader implements AssetReader {
   @override
   Future<List<int>> readAsBytes(AssetId id) async {
     final filePath = _filePathForId(id);
-    numAssetsReadFromDisk++;
+    _fileReadCount++;
     return (await _fileSystem.find(filePath)).readAsBytes();
   }
 
   @override
   Future<String> readAsString(AssetId id, {Encoding encoding: UTF8}) async {
     final filePath = _filePathForId(id);
-    numAssetsReadFromDisk++;
+    _fileReadCount++;
     return (await _fileSystem.find(filePath)).readAsString(encoding: encoding);
   }
 

--- a/bazel_codegen/lib/src/run_builders.dart
+++ b/bazel_codegen/lib/src/run_builders.dart
@@ -106,5 +106,5 @@ Future<Null> runBuilders(
     ..stop()
     ..writeLogSummary(logger);
 
-  logger.info('Read ${reader.numAssetsReadFromDisk} files from disk');
+  logger.info('Read ${reader.fileReadCount} files from disk');
 }


### PR DESCRIPTION
Rename to fileReadCount so it is shorter and follows Effective Dart
guidelines. Make the field private exposed via a getter so the public
API is more sensible.