### PR TITLE
Remove `_assetsWritten` from `BazelAssetWriter`

### DIFF
--- a/bazel_codegen/lib/src/assets/asset_filter.dart
+++ b/bazel_codegen/lib/src/assets/asset_filter.dart
@@ -5,8 +5,6 @@ import 'package:build/build.dart';
 
 import 'package:path/path.dart' as p;
 
-import 'asset_writer.dart';
-
 /// A filter for determining whether an Asset can be read during the active
 /// phase.
 ///
@@ -16,11 +14,12 @@ import 'asset_writer.dart';
 class AssetFilter {
   final Set<String> _knownValidAssets;
   final Map<String, String> _packageMap;
-  final BazelAssetWriter _assetWriter;
+  AssetWriterSpy _assetWriter;
 
-  AssetFilter(this._knownValidAssets, this._packageMap, this._assetWriter);
+  AssetFilter(this._knownValidAssets, this._packageMap);
 
   bool isValid(AssetId id) {
+    assert(_assetWriter != null);
     if (_knownValidAssets != null) {
       var packagePath = _packageMap[id.package];
       if (packagePath == null) return false;
@@ -28,4 +27,6 @@ class AssetFilter {
     }
     return !_assetWriter.assetsWritten.contains(id);
   }
+
+  void startPhase(AssetWriterSpy assetWriter) => _assetWriter = assetWriter;
 }

--- a/bazel_codegen/lib/src/assets/asset_reader.dart
+++ b/bazel_codegen/lib/src/assets/asset_reader.dart
@@ -79,10 +79,15 @@ class BazelAssetReader implements AssetReader {
       .findAssets(_packageMap[_rootPackage], glob)
       .map((path) => new AssetId(_rootPackage, path))
       .where(_assetFilter.isValid);
+
+  void startPhase(AssetWriterSpy assetWriter) =>
+      _assetFilter.startPhase(assetWriter);
 }
 
 class _AllowAllAssets implements AssetFilter {
   const _AllowAllAssets();
   @override
   bool isValid(AssetId id) => true;
+  @override
+  void startPhase(AssetWriterSpy assetWriter) {}
 }

--- a/bazel_codegen/lib/src/assets/asset_writer.dart
+++ b/bazel_codegen/lib/src/assets/asset_writer.dart
@@ -15,7 +15,6 @@ import '../errors.dart';
 class BazelAssetWriter implements AssetWriter {
   final String _outDir;
   final Map<String, String> _packageMap;
-  final assetsWritten = new Set<AssetId>();
 
   /// Workspace relative paths that we can't overwrite.
   final Set<String> _inputs;
@@ -26,7 +25,6 @@ class BazelAssetWriter implements AssetWriter {
   @override
   Future writeAsBytes(AssetId id, List<int> bytes) async {
     var file = _fileForId(id);
-    assetsWritten.add(id);
     await file.create(recursive: true);
     await file.writeAsBytes(bytes);
   }
@@ -35,7 +33,6 @@ class BazelAssetWriter implements AssetWriter {
   Future writeAsString(AssetId id, String contents,
       {Encoding encoding: UTF8}) async {
     var file = _fileForId(id);
-    assetsWritten.add(id);
     await file.create(recursive: true);
     await file.writeAsString(contents, encoding: encoding);
   }

--- a/bazel_codegen/lib/src/run_phases.dart
+++ b/bazel_codegen/lib/src/run_phases.dart
@@ -136,7 +136,7 @@ Future<IOSinkLogHandle> _runBuilders(
       validInputs: validInputs);
   final reader = new BazelAssetReader(
       packageName, buildArgs.rootDirs, packageMap,
-      assetFilter: new AssetFilter(validInputs, packageMap, writer));
+      assetFilter: new AssetFilter(validInputs, packageMap));
   var logHandle = new IOSinkLogHandle.toFile(buildArgs.logPath,
       printLevel: buildArgs.logLevel, printToStdErr: !buildArgs.isWorker);
   Resolvers resolvers;


### PR DESCRIPTION
Wrap the writer in a spy to track assets written instead of tracking
directly on the class.

- Allows taking an `AssetWriter` instead of the implementation which is
  easier to stub for tests.
- More explicitly communicates intention through `startPhase` on the
  reader and the `AssetFilter` rather than implicity relying on clearing
  the set between phases.