### PR TITLE
Add a happy case test for runBuilders

### DIFF
--- a/bazel_codegen/lib/src/run_builders.dart
+++ b/bazel_codegen/lib/src/run_builders.dart
@@ -10,7 +10,6 @@ import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 
 import '../_bazel_codegen.dart';
-import 'args/build_args.dart';
 import 'assets/asset_reader.dart';
 import 'assets/path_translation.dart';
 import 'timing.dart';
@@ -24,7 +23,8 @@ import 'timing.dart';
 /// The [timings] instance must already be started.
 Future<Null> runBuilders(
     List<BuilderFactory> builders,
-    BuildArgs buildArgs,
+    String packagePath,
+    Map<String, List<String>> buildExtensions,
     Map<String, String> defaultContent,
     List<String> srcPaths,
     Map<String, String> packageMap,
@@ -38,8 +38,8 @@ Future<Null> runBuilders(
     Set<String> validInputs}) async {
   assert(timings.isRunning);
 
-  final srcAssets = findAssetIds(srcPaths, buildArgs.packagePath, packageMap)
-      .where((id) => buildArgs.buildExtensions.keys.any(id.path.endsWith))
+  final srcAssets = findAssetIds(srcPaths, packagePath, packageMap)
+      .where((id) => buildExtensions.keys.any(id.path.endsWith))
       .toList();
 
   var allWrittenAssets = new Set<AssetId>();
@@ -58,7 +58,7 @@ Future<Null> runBuilders(
     } catch (e, s) {
       logger.severe(
           'Caught error during code generation step '
-          '$builder on ${buildArgs.packagePath}',
+          '$builder on $packagePath',
           e,
           s);
     }
@@ -81,8 +81,8 @@ Future<Null> runBuilders(
     var writes = <Future>[];
     // Check all expected outputs were written or create w/provided default.
     for (var assetId in srcAssets) {
-      for (var inputExtension in buildArgs.buildExtensions.keys) {
-        for (var extension in buildArgs.buildExtensions[inputExtension]) {
+      for (var inputExtension in buildExtensions.keys) {
+        for (var extension in buildExtensions[inputExtension]) {
           var expectedAssetId = new AssetId(
               assetId.package,
               assetId.path.substring(

--- a/bazel_codegen/lib/src/run_phases.dart
+++ b/bazel_codegen/lib/src/run_phases.dart
@@ -149,9 +149,21 @@ Future<IOSinkLogHandle> _runBuilders(
     resolvers = const BarbackResolvers();
     builderArgs = buildArgs.additionalArgs;
   }
-  await runBuilders(builders, buildArgs, defaultContent, srcPaths, packageMap,
-      timings, writer, reader, logHandle.logger, resolvers, builderArgs,
-      isWorker: isWorker, validInputs: validInputs);
+  await runBuilders(
+      builders,
+      buildArgs.packagePath,
+      buildArgs.buildExtensions,
+      defaultContent,
+      srcPaths,
+      packageMap,
+      timings,
+      writer,
+      reader,
+      logHandle.logger,
+      resolvers,
+      builderArgs,
+      isWorker: isWorker,
+      validInputs: validInputs);
   return logHandle;
 }
 

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -19,5 +19,6 @@ dependencies:
   stack_trace: ^1.7.0
 
 dev_dependencies:
+  build_test: ^0.8.0
   test: ^0.12.15+2
   test_descriptor: ^1.0.0

--- a/bazel_codegen/test/run_builders_test.dart
+++ b/bazel_codegen/test/run_builders_test.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:build/build.dart';
+import 'package:build_barback/build_barback.dart';
+import 'package:build_test/build_test.dart';
+import 'package:logging/logging.dart';
+
+import 'package:_bazel_codegen/src/run_builders.dart';
+import 'package:_bazel_codegen/src/timing.dart';
+
+import 'utils.dart';
+
+void main() {
+  group('runBuilders', () {
+    InMemoryAssetWriter writer;
+    InMemoryBazelAssetReader reader;
+    Logger logger;
+    setUp(() async {
+      writer = new InMemoryAssetWriter();
+      reader = new InMemoryBazelAssetReader();
+      logger = new Logger('bazel_codegen_test');
+    });
+    test('happy case', () async {
+      var builder = new CopyBuilder();
+      reader.cacheStringAsset(new AssetId('foo', 'lib/source.txt'), 'source');
+      await runBuilders(
+        [(_) => builder],
+        'foo',
+        builder.buildExtensions,
+        {},
+        ['foo/lib/source.txt'],
+        {'foo': 'foo'},
+        new CodegenTiming()..start(),
+        writer,
+        reader,
+        logger,
+        const BarbackResolvers(),
+        [],
+      );
+      expect(writer.assets.keys,
+          contains(new AssetId('foo', 'lib/source.txt.copy')));
+    });
+  });
+}

--- a/bazel_codegen/test/utils.dart
+++ b/bazel_codegen/test/utils.dart
@@ -1,0 +1,13 @@
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+
+import 'package:_bazel_codegen/src/assets/asset_reader.dart';
+
+class InMemoryBazelAssetReader extends InMemoryAssetReader
+    implements BazelAssetReader {
+  @override
+  int get fileReadCount => assetsRead.length;
+
+  @override
+  void startPhase(AssetWriterSpy assetWriter) {}
+}


### PR DESCRIPTION
- Replace `BuildArgs` argument with `packagePath` and `buildExtensions`
  since they are easier to construct for a test
- Add a test implementation of `BazelAssetReader`
- Add a simple happy path test case for `runBuilders`