### PR TITLE
Allow build 0.12.x with bazel_codegen

### DIFF
--- a/bazel_codegen/CHANGELOG.md
+++ b/bazel_codegen/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.1+1
+
+- Expand constraint on `package:build` to allow version `0.12.x`
+
 # 0.3.1
 
 - Correct expected outputs when running builders taking disjoint input

--- a/bazel_codegen/lib/src/assets/asset_reader.dart
+++ b/bazel_codegen/lib/src/assets/asset_reader.dart
@@ -12,7 +12,7 @@ import '../errors.dart';
 import 'asset_filter.dart';
 import 'file_system.dart';
 
-class BazelAssetReader implements AssetReader {
+class BazelAssetReader extends AssetReader {
   final String _rootPackage;
 
   /// The bazel specific file system.

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -2,7 +2,7 @@ name: _bazel_codegen
 description: Bazel code generation runner
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/bazel
-version: 0.3.1
+version: 0.3.1+1
 
 environment:
   sdk: ">=1.21.1 <2.0.0"
@@ -11,7 +11,7 @@ dependencies:
   analyzer: ^0.29.5
   args: ^0.13.6
   bazel_worker: ^0.1.2
-  build: ^0.11.1
+  build: ">=0.11.1 <0.13.0"
   build_barback: ^0.4.0
   glob: ^1.1.0
   logging: ^0.11.3

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -12,13 +12,13 @@ dependencies:
   args: ^0.13.6
   bazel_worker: ^0.1.2
   build: ">=0.11.1 <0.13.0"
-  build_barback: ^0.4.0
+  build_barback: ">=0.4.0 <0.6.0"
   glob: ^1.1.0
   logging: ^0.11.3
   path: ^1.4.1
   stack_trace: ^1.7.0
 
 dev_dependencies:
-  build_test: ^0.9.2
-  test: ^0.12.15+2
+  build_test: ^0.10.0
+  test: ^0.12.15
   test_descriptor: ^1.0.0

--- a/bazel_codegen/test/run_builders_test.dart
+++ b/bazel_codegen/test/run_builders_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:test/test.dart';
 
 import 'package:build/build.dart';
@@ -33,7 +31,7 @@ void main() {
     });
 
     test('happy case', () async {
-      var builder = new CopyBuilder();
+      var builder = new TestBuilder();
       reader.cacheStringAsset(new AssetId('foo', 'lib/source.txt'), 'source');
       await runBuilders(
         [(_) => builder],
@@ -54,10 +52,10 @@ void main() {
     });
 
     test('multiple input extensions expects correct outputs', () async {
-      final builderFoo =
-          new CopyBuilder(inputExtension: '.foo', extension: 'foo.copy');
-      final builderBar =
-          new CopyBuilder(inputExtension: '.bar', extension: 'bar.copy');
+      final builderFoo = new TestBuilder(
+          buildExtensions: appendExtension('.copy', from: '.foo'));
+      final builderBar = new TestBuilder(
+          buildExtensions: appendExtension('.copy', from: '.bar'));
       reader.cacheStringAsset(new AssetId('a', 'lib/a1.foo'), 'foo content');
       reader.cacheStringAsset(new AssetId('a', 'lib/a2.bar'), 'bar content');
       await runBuilders(


### PR DESCRIPTION
Switch the AssetReader implementation to `extends` to pick up
implementation of digest method.